### PR TITLE
adding rule that detect tag line being partially commented out

### DIFF
--- a/.gherkin-lintrc
+++ b/.gherkin-lintrc
@@ -3,5 +3,6 @@
   "no-unamed-features": "on",
   "no-unamed-scenarios": "on",
   "no-dupe-scenario-names": "on",
-  "no-dupe-feature-names": "on"
+  "no-dupe-feature-names": "on",
+  "no-partially-commented-tag-lines": "on"
 }

--- a/README.md
+++ b/README.md
@@ -14,22 +14,23 @@ To see the output for all the errors that the linter can detect run:
 git clone https://github.com/vsiakka/gherkin-lint.git
 npm run demo
 ```
-Or check this: 
+Or check this:
 ![console](http://i.imgur.com/YaH4Anu.png)
 
 
 ## Available rules
 
 | Name                           | Functionality                                             | Configurable |
-|--------------------------------|-----------------------------------------------------------|:------------:|
-| `one-feature-per-file`         | Disallows multiple Feature definitions in the same file   | no*          |
-| `up-to-one-background-per-file`| Disallows multiple Background definition in the same file | no*          |
-| `no-empty-file`                | Disallows empty feature files                             | no*          |
-| `no-files-without-scenarios`   | Disallows files with no scenarios                         | yes          |
-| `no-unamed-features`           | Disallows empty Feature name                              | yes          |
-| `no-unamed-scenarios`          | Disallows empty Scenario name                             | yes          |
-| `no-dupe-feature-names`        | Disallows duplicate Feature names                         | yes          |
-| `no-dupe-scenario-names`       | Disallows duplicate Scenario names                        | yes          |
+|------------------------------------|-----------------------------------------------------------|:------------:|
+| `one-feature-per-file`             | Disallows multiple Feature definitions in the same file   | no*          |
+| `up-to-one-background-per-file`    | Disallows multiple Background definition in the same file | no*          |
+| `no-empty-file`                    | Disallows empty feature files                             | no*          |
+| `no-files-without-scenarios`       | Disallows files with no scenarios                         | yes          |
+| `no-unamed-features`               | Disallows empty Feature name                              | yes          |
+| `no-unamed-scenarios`              | Disallows empty Scenario name                             | yes          |
+| `no-dupe-feature-names`            | Disallows duplicate Feature names                         | yes          |
+| `no-dupe-scenario-names`           | Disallows duplicate Scenario names                        | yes          |
+| `no-partially-commented-tag-lines` | Disallows partially commented tag lines                   | yes          |
 
 \* These rules cannot be turned off because they detect undocumented cucumber functionality that causes the [gherkin](https://github.com/cucumber/gherkin-javascript) parser to crash.
 

--- a/src/rules/no-partially-commented-tag-lines.js
+++ b/src/rules/no-partially-commented-tag-lines.js
@@ -1,0 +1,20 @@
+var rule = 'no-partially-commented-tag-lines';
+
+function noPartiallyCommentedTagLines(parsedFile) {
+  var errors = [];
+  parsedFile.scenarioDefinitions.forEach(function(scenario) {
+    scenario.tags.forEach(function(tag) {
+      if (tag.name.indexOf('#') > 0) {
+        errors.push({message: 'Partially commented tag lines not allowed ',
+                     rule   : rule,
+                     line   : parsedFile.location.line});
+      }
+    });
+  });
+  return errors;
+}
+
+module.exports = {
+  name: rule,
+  run: noPartiallyCommentedTagLines
+};

--- a/test-data/PartiallyCommentedTagLine.feature
+++ b/test-data/PartiallyCommentedTagLine.feature
@@ -1,0 +1,8 @@
+Feature: Test for the no-partially-commented-tag-lines
+
+Background:
+  Given I have a Feature file with a line with tags that is half commented out
+
+@tag #@commented-out-tag
+Scenario: This is Scenario for no-partially-commented-tag-lines
+  Then I should see a no-partially-commented-tag-lines error


### PR DESCRIPTION
The gherkin parser doesn't parse partially commented lines in the way you would expect, eg it will break down `@t1 #@t2` in `@t1 #` and `@t2` 