### PR TITLE
Adding rule for enforcing/disallowing new line at the EOF and bugfixes

### DIFF
--- a/.gherkin-lintrc
+++ b/.gherkin-lintrc
@@ -6,5 +6,6 @@
   "no-dupe-feature-names": "on",
   "no-partially-commented-tag-lines": "on",
   "indentation": "on",
-  "no-trailing-spaces": "on"
+  "no-trailing-spaces": "on",
+  "new-line-at-eof": ["on", "yes"]
 }

--- a/README.md
+++ b/README.md
@@ -34,6 +34,7 @@ Or check this:
 | `no-partially-commented-tag-lines` | Disallows partially commented tag lines                   | yes          |
 | `indentation`                      | Allows the user to specify indentation rules              | yes          |
 | `no-trailing-spaces`               | Disallows trailing spaces                                 | yes          |
+| `new-line-at-eof`                  | Disallows/enforces new line at EOF                        | yes          |
 
 \* These rules cannot be turned off because they detect undocumented cucumber functionality that causes the [gherkin](https://github.com/cucumber/gherkin-javascript) parser to crash.
 
@@ -56,6 +57,20 @@ You can override the defaults for `indentation` like this:
 ```
 {
   "indentation" : "on", { "feature": 0, "background": 0, "scenario": 0, "step": 2 }
+}
+```
+
+`new-line-at-eof` can also be configured to enforcing or disallowing new lines at EOF.
+- To enforce new lines at EOF:
+```
+{
+  "new-line-at-eof": ["on", "yes"]
+}
+```
+- To disallow new lines at EOF:
+```
+{
+  "new-line-at-eof": ["on", "no"]
 }
 ```
 

--- a/src/formatters/stylish.js
+++ b/src/formatters/stylish.js
@@ -15,7 +15,7 @@ function stylizeError(error, maxErrorMsgLength, maxLineChars) {
   var str = '  '; // indent 2 spaces so it looks pretty
   var padding = '    '; //padding of 4 spaces, will be used between line numbers, error msgs and rule names
 
-  var line = error.line;
+  var line = error.line.toString();
   // add spaces until the line string is as long as our longest line string
   while (line.length < maxLineChars) {
     line += ' ';
@@ -48,8 +48,9 @@ function getMaxLengthOfField(results, field) {
   var length = 0;
   results.forEach(function(result) {
     result.errors.forEach(function(error) {
-      if (error[field].length > length) {
-        length = error[field].length;
+      var errorStr = error[field].toString();
+      if (errorStr.length > length) {
+        length = errorStr.length;
       }
     });
   });

--- a/src/linter.js
+++ b/src/linter.js
@@ -1,4 +1,5 @@
 var fs = require('fs');
+var _ = require('lodash');
 var Gherkin = require('gherkin');
 var parser = new Gherkin.Parser();
 var rules = require('./rules.js');
@@ -19,7 +20,7 @@ function lint(files, configuration) {
         throw e;
       }
     }
-    var fileBlob = {filePath: fs.realpathSync(fileName), errors: errors};
+    var fileBlob = {filePath: fs.realpathSync(fileName), errors: _.sortBy(errors, 'line')};
     output.push(fileBlob);
   });
 

--- a/src/rules.js
+++ b/src/rules.js
@@ -47,24 +47,30 @@ function runAllEnabledRules(parsedFile, fileName, configuration) {
 
 function verifyRuleConfiguration(rule, ruleConfig) {
   var enablingSettings = ['on', 'off'];
-  var genericErrorMsg = 'Invalid rule configuration - ';
+  var genericErrorMsg = 'Invalid rule configuration for "' + rule + '" - ';
 
   if (Array.isArray(ruleConfig)) {
     if (enablingSettings.indexOf(ruleConfig[0]) == -1) {
       throw new Error(genericErrorMsg + 'The first part of the config should be "on" or "off"');
     }
-    if (ruleConfig.length != 2 || typeof(ruleConfig[1]) !== 'object') {
-      throw new Error(genericErrorMsg + ' The config should only have 2 parts and the second part should be a keyworded map');
-    }
-    var ruleObj = getRule(rule);
 
-    for (var subConfig in ruleConfig[1]) {
+    if (ruleConfig.length != 2 ) {
+      throw new Error(genericErrorMsg + ' The config should only have 2 parts.');
+    }
+
+    var ruleObj = getRule(rule);
+    var extraConfig = typeof(ruleConfig[1]) === 'String' ? ruleConfig[1] : [ruleConfig[1]];
+    
+    for (var subConfig in extraConfig) {
       if (ruleObj.availableConfigs[subConfig] === undefined) {
-        throw new Error(genericErrorMsg + ' The rule does not have the specified configuration argument');
+        throw new Error(genericErrorMsg + ' The rule does not have the specified configuration option "' + subConfig + '"');
       }
     }
+  } else {
+    if (enablingSettings.indexOf(ruleConfig) == -1) {
+      throw new Error(genericErrorMsg + 'The the config should be "on" or "off"');
+    }
   }
-  return enablingSettings.indexOf(ruleConfig) != -1;
 }
 
 module.exports = {

--- a/src/rules/new-line-at-eof.js
+++ b/src/rules/new-line-at-eof.js
@@ -1,4 +1,5 @@
 var fs = require('fs');
+var _ = require('lodash');
 var rule = 'new-line-at-eof';
 
 var availableConfigs = [
@@ -7,6 +8,10 @@ var availableConfigs = [
 ]
 
 function newLineAtEOF(unused, fileName, configuration) {
+  if (_.indexOf(availableConfigs, configuration) === -1) {
+    throw new Error(rule + ' requires an extra configuration value.\nAvailable configurations: ' + availableConfigs.join(', ') + '\nFor syntax please look at the documentation.');
+  }
+
   var fileContent = fs.readFileSync(fileName).toString();
   var hasNewLineAtEOF = fileContent.match(/(\r\n|\r|\n)+$/);
   var errormsg = '';

--- a/src/rules/new-line-at-eof.js
+++ b/src/rules/new-line-at-eof.js
@@ -1,0 +1,31 @@
+var fs = require('fs');
+var rule = 'new-line-at-eof';
+
+var availableConfigs = [
+  "yes",
+  "no"
+]
+
+function newLineAtEOF(unused, fileName, configuration) {
+  var fileContent = fs.readFileSync(fileName).toString();
+  var hasNewLineAtEOF = fileContent.match(/(\r\n|\r|\n)+$/);
+  var errormsg = '';
+  if (hasNewLineAtEOF && configuration === "no")
+  {
+    errormsg = 'New line at EOF(end of file) is not allowed';
+  } else if (!hasNewLineAtEOF && configuration === "yes") {
+    errormsg = 'New line at EOF(end of file) is required';
+  }
+
+  if (errormsg !== '') {
+    return {message: errormsg,
+            rule   : rule,
+            line   : fileContent.split('\n').length};
+  }
+}
+
+module.exports = {
+  name: rule,
+  run: newLineAtEOF,
+  availableConfigs: availableConfigs
+};

--- a/test-data/DuplicateFeatureName-Pt1.feature
+++ b/test-data/DuplicateFeatureName-Pt1.feature
@@ -1,9 +1,9 @@
 Feature: Test for the no-dupe-feature-names rule
 
-Scenario: This is a Scenario 1 for no-dupe-feature-names
+Scenario: This is Scenario 1 for no-dupe-feature-names
   Given I have 2 feature files with the same name
   Then I should see a no-dupe-feature-names error
 
-Scenario: This is a Scenario 2 for no-dupe-feature-names
+Scenario: This is Scenario 2 for no-dupe-feature-names
   Given I have 2 feature files with the same name
   Then I should see a no-dupe-feature-names error

--- a/test-data/DuplicateFeatureName-Pt2.feature
+++ b/test-data/DuplicateFeatureName-Pt2.feature
@@ -1,9 +1,9 @@
 Feature: Test for the no-dupe-feature-names rule
 
-Scenario: This is a Scenario 3 for no-dupe-feature-names
+Scenario: This is Scenario 3 for no-dupe-feature-names
   Given I have 2 feature files with the same name
   Then I should see a no-dupe-feature-names error
 
-Scenario: This is a Scenario 4 for no-dupe-feature-names
+Scenario: This is Scenario 4 for no-dupe-feature-names
   Given I have 2 feature files with the same name
   Then I should see a no-dupe-feature-names error

--- a/test-data/NoLineAtEOF.feature
+++ b/test-data/NoLineAtEOF.feature
@@ -1,0 +1,5 @@
+Feature: Test for the new-line-at-eof rule
+
+Scenario: This is Scenario for new-line-at-eof
+  Given I don't have a new line at the end of this file
+  Then I should see a new-line-at-eof error

--- a/test-data/NoNewLineAtEOF.feature
+++ b/test-data/NoNewLineAtEOF.feature
@@ -1,5 +1,5 @@
 Feature: Test for the new-line-at-eof rule
 
-Scenario: This is Scenario for new-line-at-eof
+Scenario: This is a Scenario for new-line-at-eof
   Given I don't have a new line at the end of this file
   Then I should see a new-line-at-eof error

--- a/test-data/PartiallyCommentedTagLine.feature
+++ b/test-data/PartiallyCommentedTagLine.feature
@@ -4,5 +4,5 @@ Background:
   Given I have a Feature file with a line with tags that is half commented out
 
 @tag #@commented-out-tag
-Scenario: This is Scenario for no-partially-commented-tag-lines
+Scenario: This is a Scenario for no-partially-commented-tag-lines
   Then I should see a no-partially-commented-tag-lines error

--- a/test-data/TagOnBackground.feature
+++ b/test-data/TagOnBackground.feature
@@ -4,5 +4,5 @@ Feature: Test for the no-tags-on-backgrounds
 Background:
   Given I have a Feature file with a tag on a background
 
-Scenario: This is Scenario for no-tags-on-backgrounds
+Scenario: This is a Scenario for no-tags-on-backgrounds
   Then I should see a no-tags-on-backgrounds

--- a/test-data/UnnamedFeature.feature
+++ b/test-data/UnnamedFeature.feature
@@ -1,5 +1,5 @@
 Feature:
 
-Scenario: Test for the no-unamed-features rule
+Scenario: This is a Scenario for no-unamed-features
   Given I have an unamed Feature
   Then I should see a no-unamed-features error

--- a/test-data/WrongIndentation.feature
+++ b/test-data/WrongIndentation.feature
@@ -3,5 +3,5 @@
     Background:
 Given I have a Feature file with indentation all over the place
 
- Scenario: This is Scenario for indentation
+ Scenario: This is a Scenario for indentation
         Then I should see an indentation error


### PR DESCRIPTION
1.Adding rule for enforcing/disallowing new line at the EOF
2.Fixing padding for output printing for line numbers that have different number of digits
3.Fixing rule configuration verification, verification would not catch rules that were configured with just one string that wasn't 'on' or 'off' 
4. Fixing typos in several test .feature files