### PR TITLE
fix: make sure the errors object is empty when a new feature file is parsed

### DIFF
--- a/src/rules/indetation.js
+++ b/src/rules/indetation.js
@@ -20,6 +20,7 @@ function test(parsedLocation, config, type) {
 }
 
 function indentation(parsedFile, unused, configuration) {
+  errors = [];
   configuration = _.merge(availableConfigs, configuration);
 
   // Check Feature indentation


### PR DESCRIPTION
This fixes #23 