### PR TITLE
fix: use console.error instead of console.log

### DIFF
--- a/src/formatters/json.js
+++ b/src/formatters/json.js
@@ -1,7 +1,7 @@
 /*eslint no-console: "off"*/
 
 function printResults(results) {
-  console.log(JSON.stringify(results));
+  console.error(JSON.stringify(results));
 }
 
 module.exports = {

--- a/src/formatters/stylish.js
+++ b/src/formatters/stylish.js
@@ -64,12 +64,12 @@ function printResults(results) {
 
   results.forEach(function(result) {
     if (result.errors.length > 0) {
-      console.log(stylizeFilePath(result.filePath));
+      console.error(stylizeFilePath(result.filePath));
 
       result.errors.forEach(function(error) {
-        console.log(stylizeError(error, maxErrorMsgLength, maxLineChars));
+        console.error(stylizeError(error, maxErrorMsgLength, maxLineChars));
       });
-      console.log('\n');
+      console.error('\n');
     }
   });
 }


### PR DESCRIPTION
this fixes e.g. output in a Jenkins console, since normal console.log statements are mapped to INFO instead of ERROR