### PR TITLE
fix: update trailing spaces rule to catch any whitespace character

### DIFF
--- a/src/rules/no-trailing-spaces.js
+++ b/src/rules/no-trailing-spaces.js
@@ -6,7 +6,7 @@ function noTrailingSpaces(parsedFile, fileName) {
   var lines = fs.readFileSync(fileName).toString().split('\n');
   var lineNo = 1;
   lines.forEach(function(line) {
-    if (line[line.length - 1] == ' ') {
+    if (/[\s]+$/.test(line)) {
       errors.push({message: 'Trailing spaces are not allowed',
                    rule   : rule,
                    line   : lineNo});

--- a/test-data/TrailingTab.feature
+++ b/test-data/TrailingTab.feature
@@ -1,0 +1,4 @@
+Feature: Test for trailing tabs
+	
+Scenario: This is Scenario for no-trailing-spaces - using tabs
+  Then I should see a no-trailing-spaces error	


### PR DESCRIPTION
If the line ends with one ore more whitespace characters, mark it as an error.
I've added an example with tabs, too