### PR TITLE
Trailing spaces rule incorrectly detected new line characters at the …

### DIFF
--- a/src/rules/no-trailing-spaces.js
+++ b/src/rules/no-trailing-spaces.js
@@ -6,7 +6,7 @@ function noTrailingSpaces(parsedFile, fileName) {
   var lines = fs.readFileSync(fileName).toString().split('\n');
   var lineNo = 1;
   lines.forEach(function(line) {
-    if (/[\s]+$/.test(line)) {
+    if (/[\t ]+[\n\r]*$/.test(line)) {
       errors.push({message: 'Trailing spaces are not allowed',
                    rule   : rule,
                    line   : lineNo});

--- a/test-data/TrailingTab.feature
+++ b/test-data/TrailingTab.feature
@@ -1,4 +1,4 @@
 Feature: Test for trailing tabs
-	
+
 Scenario: This is Scenario for no-trailing-spaces - using tabs
-  Then I should see a no-trailing-spaces error	
+  Then I should see a no-trailing-spaces error			


### PR DESCRIPTION
…end of the line, changing it to detect tabs and spaces instead