### PR TITLE
Add name-length rule

### DIFF
--- a/package.json
+++ b/package.json
@@ -39,7 +39,8 @@
   "scripts": {
     "demo": "node ./src/main.js . -c ./test-data-wip/.gherkin-lintrc",
     "lint": "eslint .",
-    "test": "npm run lint && mocha --recursive"
+    "mocha": "mocha --recursive",
+    "test": "npm run lint && npm run mocha"
   },
   "license": "ISC"
 }

--- a/src/rules/name-length.js
+++ b/src/rules/name-length.js
@@ -1,0 +1,59 @@
+var _ = require('lodash');
+var rule = 'name-length';
+
+var availableConfigs = {
+  'Feature': 70,
+  'Step': 70,
+  'Scenario': 70
+};
+
+var errors = [];
+
+function test(name, location, configuration, type) {
+  if (name && (name.length > configuration[type])) {
+    errors.push({message: type + ' name is too long. Length of ' + name.length + ' is longer than the maximum allowed: ' + configuration[type],
+                 rule   : rule,
+                 line   : location.line});
+  }
+}
+
+function nameLength(parsedFile, unused, configuration) {
+  if (!parsedFile || Object.keys(parsedFile).length === 0) {
+    return;
+  }
+  var mergedConfiguration = _.merge(availableConfigs, configuration);
+  errors = [];
+
+  // Check Feature name length
+  test(parsedFile.name, parsedFile.location, mergedConfiguration, 'Feature');
+
+  parsedFile.children.forEach(function(child) {
+    switch(child.type) {
+    case 'Scenario':
+    case 'ScenarioOutline':
+      // Check Scenario name length
+      test(child.name, child.location, mergedConfiguration, 'Scenario');
+      break;
+    case 'Background':
+      break;
+    default:
+      errors.push({message: 'Unknown gherkin node type ' + child.type,
+                   rule   : rule,
+                   line   : child.location.line});
+      break;
+    }
+
+    child.steps.forEach(function(step) {
+      // Check Step name length
+      test(step.text, step.location, mergedConfiguration, 'Step');
+    });
+  });
+
+  return errors;
+}
+
+module.exports = {
+  name: rule,
+  run: nameLength,
+  availableConfigs: availableConfigs
+};

--- a/test-data-wip/.gherkin-lintrc
+++ b/test-data-wip/.gherkin-lintrc
@@ -10,5 +10,6 @@
   "new-line-at-eof": ["on", "yes"],
   "no-multiple-empty-lines": "on",
   "no-empty-file": "on",
-  "no-scenario-outlines-without-examples": "on"
+  "no-scenario-outlines-without-examples": "on",
+  "name-length": ["on", {"Feature": 50}]
 }

--- a/test/rules/name-length/test-data/CorrectLength.feature
+++ b/test/rules/name-length/test-data/CorrectLength.feature
@@ -1,0 +1,13 @@
+Feature: Test for length - less than 70 characters
+
+Background:
+  Given I have a Feature file with great lengths
+
+Scenario: This is a Scenario with correct length
+  Then I should not see a length error
+
+Scenario Outline: This is a Scenario Outline with correct length
+  Then I should not see a length error
+Examples:
+  | foo |
+  | bar |

--- a/test/rules/name-length/test-data/WrongLength.feature
+++ b/test/rules/name-length/test-data/WrongLength.feature
@@ -1,0 +1,13 @@
+Feature: Test for length - more than 70 characters more than 70 characters more than 70 characters 
+
+Background:
+  Given I have a Feature file with incorrect lengths - more than 70 characters more than 70 characters 
+
+Scenario: This is a Scenario with incorrect length - more than 70 characters more than 70 characters 
+  Then I should see a length error - more than 70 characters more than 70 characters more than 70 characters 
+
+Scenario Outline: This is a Scenario Outline with incorrect length - more than 70 characters more than 70 characters 
+  Then I should see a length error - more than 70 characters more than 70 characters more than 70 characters 
+Examples:
+  | foo |
+  | bar |

--- a/test/rules/name-length/test-results/results.js
+++ b/test/rules/name-length/test-results/results.js
@@ -1,0 +1,28 @@
+module.exports = {
+  'wrongLength':[ 
+    { message: 'Feature name is too long. Length of 89 is longer than the maximum allowed: 70',
+      rule: 'name-length',
+      line: 1 
+    },
+    { message: 'Step name is too long. Length of 94 is longer than the maximum allowed: 70',
+      rule: 'name-length',
+      line: 4 
+    },
+    { message: 'Scenario name is too long. Length of 90 is longer than the maximum allowed: 70',
+      rule: 'name-length',
+      line: 6 
+    },
+    { message: 'Step name is too long. Length of 101 is longer than the maximum allowed: 70',
+      rule: 'name-length',
+      line: 7 
+    },
+    { message: 'Scenario name is too long. Length of 98 is longer than the maximum allowed: 70',
+      rule: 'name-length',
+      line: 9 
+    },
+    { message: 'Step name is too long. Length of 101 is longer than the maximum allowed: 70',
+      rule: 'name-length',
+      line: 10 
+    } 
+  ]
+};

--- a/test/rules/name-length/test.js
+++ b/test/rules/name-length/test.js
@@ -1,0 +1,34 @@
+var assert = require('chai').assert;
+var expect = require('chai').expect;
+var nameLength = require('../../../src/rules/name-length.js');
+var Gherkin = require('gherkin');
+var parser = new Gherkin.Parser();
+var fs = require('fs');
+
+var expectedResults = require('./test-results/results.js');
+
+require('mocha-sinon');
+
+function getErrors(fileName, configuration) {
+  var file = fs.readFileSync('test/rules/name-length/test-data/' + fileName, 'utf8');
+  var parsedFile = parser.parse(file).feature;
+  return nameLength.run(parsedFile, undefined, configuration);
+}
+
+
+describe('Name length rule', function() {
+  it('doesn\'t raise errors when the default configuration is used and there are no length violations', function() {
+    var configuration = ['on'];
+    var fileName = 'CorrectLength.feature';
+    var errors = getErrors(fileName, configuration);
+    expect(errors).to.be.empty;
+  });
+
+  it('detects errors for features, scenarios, scenario outlines and steps', function() {
+    var configuration = ['on'];
+    var fileName = 'WrongLength.feature';
+    var errors = getErrors(fileName, configuration);
+    assert.sameDeepMembers(errors, expectedResults.wrongLength);
+  });
+
+});


### PR DESCRIPTION
Resolves #51 

This rule raises errors if Feature, Scenario, or Step names are too long. 