### PR TITLE
add compatible terminal colors using chalk

### DIFF
--- a/package.json
+++ b/package.json
@@ -21,6 +21,7 @@
     "linter"
   ],
   "dependencies": {
+    "chalk": "^1.1.3",
     "commander": "2.9.0",
     "gherkin": "4.0.0",
     "glob": "7.0.5",

--- a/src/config-parser.js
+++ b/src/config-parser.js
@@ -3,9 +3,10 @@ var chalk = require('chalk');
 var rules = require('./rules.js');
 
 var defaultConfigFileName = '.gherkin-lintrc';
-var errors = [];
+var errors;
 
 function getConfiguration(configPath) {
+  errors = [];
   if (configPath) {
     if (!fs.existsSync(configPath)) {
       throw new Error('Could not find specified config file "' + configPath + '"');

--- a/src/config-parser.js
+++ b/src/config-parser.js
@@ -1,4 +1,5 @@
 var fs = require('fs');
+var chalk = require('chalk');
 var rules = require('./rules.js');
 
 var defaultConfigFileName = '.gherkin-lintrc';
@@ -21,9 +22,9 @@ function getConfiguration(configPath) {
   verifyConfigurationFile(config);
 
   if (errors.length > 0) {
-    console.error('\x1b[31m\x1b[1mError(s) in configuration file:\x1b[0m');  // eslint-disable-line no-console
+    console.error(chalk.red.bold('Error(s) in configuration file:'));  // eslint-disable-line no-console
     errors.forEach(function(error){
-      console.error('\x1b[31m- ' + error + '\x1b[0m');  // eslint-disable-line no-console
+      console.error(chalk.red('- ' + error));  // eslint-disable-line no-console
     });
     throw new Error('Configuration error(s)');
   }

--- a/src/formatters/stylish.js
+++ b/src/formatters/stylish.js
@@ -1,15 +1,5 @@
 /*eslint no-console: "off"*/
-
-var style = {
-  gray: function(text) {
-    return '\x1b[38;5;243m' + text + '\x1b[0m';
-  },
-
-  underline: function(text) {
-    return '\x1b[0;4m' + text + '\x1b[24m';
-  }
-
-};
+var chalk = require('chalk');
 
 function stylizeError(error, maxErrorMsgLength, maxLineChars) {
   var str = '  '; // indent 2 spaces so it looks pretty
@@ -22,7 +12,7 @@ function stylizeError(error, maxErrorMsgLength, maxLineChars) {
   }
 
   // print the line number as gray
-  str += style.gray(line) + padding;
+  str += chalk.gray(line) + padding;
 
   var errorMsg = error.message;
 
@@ -35,13 +25,13 @@ function stylizeError(error, maxErrorMsgLength, maxLineChars) {
   str += errorMsg + padding;
 
   // print the rule name in gray
-  str += style.gray(error.rule);
+  str += chalk.gray(error.rule);
 
   return str; // lastly, return our stylish-est string and pretend that this code was never written
 }
 
 function stylizeFilePath(filePath) {
-  return style.underline(filePath);
+  return chalk.underline(filePath);
 }
 
 function getMaxLengthOfField(results, field) {

--- a/test/configuration-parser/test-results/results.js
+++ b/test/configuration-parser/test-results/results.js
@@ -1,5 +1,6 @@
-module.exports =
-{
+var chalk = require('chalk');
+
+module.exports = {
   'config1': {
     'no-files-without-scenarios': 'on',
     'no-unamed-features': 'on',
@@ -19,16 +20,16 @@ module.exports =
   },
   'config4': {
     'consoleErrors': [
-      '\x1b[31m\x1b[1mError(s) in configuration file:\x1b[0m',
-      '\x1b[31m- Rule "fake-rule" does not exist\x1b[0m'
+      chalk.red.bold('Error(s) in configuration file:'),
+      chalk.red('- Rule "fake-rule" does not exist')
     ],
     'assertionMessage': 'Configuration error(s)'
   },
   'config5': {
     'consoleErrors': [
-      '\x1b[31m\x1b[1mError(s) in configuration file:\x1b[0m',
-      '\x1b[31m- Invalid rule configuration for "indentation" -  The rule does not have the specified configuration option "featur"\x1b[0m',
-      '\x1b[31m- Invalid rule configuration for "new-line-at-eof" -  The rule does not have the specified configuration option "y"\x1b[0m'
+      chalk.red.bold('Error(s) in configuration file:'),
+      chalk.red('- Invalid rule configuration for "indentation" -  The rule does not have the specified configuration option "featur"'),
+      chalk.red('- Invalid rule configuration for "new-line-at-eof" -  The rule does not have the specified configuration option "y"')
     ],
     'assertionMessage': 'Configuration error(s)'
   }

--- a/test/configuration-parser/test.js
+++ b/test/configuration-parser/test.js
@@ -26,7 +26,7 @@ describe('Configuration file', function() {
     });
   });
 
-  describe('parsing/verification throws an error when the config contails', function() {
+  describe('parsing/verification throws an error when the config contains', function() {
     beforeEach(function() {
       this.sinon.stub(console, 'error');
     });
@@ -46,9 +46,10 @@ describe('Configuration file', function() {
       assert.equal(actualAssertion, expectedAssertion);
 
       // verify the console logs
-      expected.consoleErrors.forEach(function(msg) {
-        expect(console.error.calledWith(msg)).to.be.true; // eslint-disable-line no-console
+      var consoleErrorArgs = console.error.args.map(function (args) { // eslint-disable-line no-console
+        return args[0];
       });
+      expect(consoleErrorArgs).to.be.deep.equal(expected.consoleErrors);
     });
 
     it('a non existing rule sub-config', function() {
@@ -66,9 +67,10 @@ describe('Configuration file', function() {
       assert.equal(actualAssertion, expectedAssertion);
 
       // verify the console logs
-      expected.consoleErrors.forEach(function(msg) {
-        expect(console.error.calledWith(msg)).to.be.true; // eslint-disable-line no-console
+      var consoleErrorArgs = console.error.args.map(function (args) { // eslint-disable-line no-console
+        return args[0];
       });
+      expect(consoleErrorArgs).to.be.deep.equal(expected.consoleErrors);
 
     });
 


### PR DESCRIPTION
Hi,

I added [chalk](https://www.npmjs.com/package/chalk) dependency to do this library terminal color compatible.

Also I changed the verification of two tests, because receiving that "false is not true" is a bad reporting. Because of this, I found an side effect problem not detected with the previous tests. When is called:

- parsing/verification throws an error when the config contains **a non existing rule**

and then:
- parsing/verification throws an error when the config contains **a non existing rule sub-config**

the last test does not pass. However if the las test is run isolated works perfectly. The problem occurs because `errors` variable in `config-parser.js` is global.

I will try to solve this in a next commit.

Regards!
