### PR TITLE
Implement use-and rule

### DIFF
--- a/src/rules/use-and.js
+++ b/src/rules/use-and.js
@@ -1,0 +1,31 @@
+var rule = 'use-and';
+
+function useAnd(feature) {
+  var errors = [];
+
+  feature.children.forEach(function(child) {
+    var previousKeyword = undefined;
+    child.steps.forEach(function(step) {
+      if (step.keyword === 'And ') {
+        return;
+      }
+      if (step.keyword === previousKeyword) {
+        errors.push(createError(step));
+      }
+      previousKeyword = step.keyword;
+    });
+  });
+
+  return errors;
+}
+
+function createError(step) {
+  return {message: 'Step "' + step.keyword + step.text + '" should use And instead of ' + step.keyword,
+          rule   : rule,
+          line   : step.location.line};
+}
+
+module.exports = {
+  name: rule,
+  run: useAnd
+};

--- a/test-data-wip/.gherkin-lintrc
+++ b/test-data-wip/.gherkin-lintrc
@@ -11,5 +11,6 @@
   "no-multiple-empty-lines": "on",
   "no-empty-file": "on",
   "no-scenario-outlines-without-examples": "on",
-  "name-length": ["on", {"Feature": 50}]
+  "name-length": ["on", {"Feature": 50}],
+  "use-and": "on"
 }

--- a/test-data-wip/UseAnd.feature
+++ b/test-data-wip/UseAnd.feature
@@ -1,0 +1,14 @@
+Feature: Test for the use-and rule
+
+Background:
+  Given first statement
+  And second statement with and
+  Given third statement that does not use and
+
+Scenario: A scenario for use-and rule
+  Given first given within scenario, which is fine
+  When first step
+  When second step without and
+  And third step with and
+  Then first assertion
+  Then second assertion without and


### PR DESCRIPTION
To check that repeated steps like: When, When, Then, Then, Then
Are written using And like: When, And, Then, And, And

When editing feature files, it's easy to make the mistake
of not using And when you should (e.g. when copy-pasting
existing steps to create new ones).  This linting rule ensures
that And is used consistently.

Future improvements:

I guess one might want to either apply this rule, or the opposite
of it - never using And, but repeating the step keywords instead.
For this the rule should be configurable, something like:

    use-and: ["on", "always"/"never"]