### PR TITLE
Document no-restricted-tags

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,26 +24,26 @@ Or check this:
 
 ## Available rules
 
-| Name                                    | Functionality                                             |
-|-----------------------------------------|-----------------------------------------------------------|
-| `no-tags-on-backgrounds` *              | Disallows tags on Background                              |
-| `one-feature-per-file` *                | Disallows multiple Feature definitions in the same file   |
-| `up-to-one-background-per-file` *       | Disallows multiple Background definition in the same file |
-| &nbsp;                                  |                                                           |
-| [`indentation`](#indentation)           | Allows the user to specify indentation rules              |
-| [`new-line-at-eof`](#new-line-at-eof)   | Disallows/enforces new line at EOF                        |
-| `no-dupe-feature-names`                 | Disallows duplicate Feature names                         |
-| `no-dupe-scenario-names`                | Disallows duplicate Scenario names                        |
-| `no-empty-file`                         | Disallows empty feature files                             |
-| `no-files-without-scenarios`            | Disallows files with no scenarios                         |
-| `no-multiple-empty-lines`               | Disallows multiple empty lines                            |
-| `no-partially-commented-tag-lines`      | Disallows partially commented tag lines                   |
-| [`no-restricted-tags`](#no-restricted-tags) | Disallow use of particular @tags                          |
-| `no-scenario-outlines-without-examples` | Disallows scenario outlines without examples              |
-| `no-trailing-spaces`                    | Disallows trailing spaces                                 |
-| `no-unnamed-features`                   | Disallows empty Feature name                              |
-| `no-unnamed-scenarios`                  | Disallows empty Scenario name                             |
-| `use-and`                               | Disallows repeated step names requiring use of And instead|
+| Name                                        | Functionality                                              |
+|---------------------------------------------|------------------------------------------------------------|
+| `no-tags-on-backgrounds` *                  | Disallows tags on Background                               |
+| `one-feature-per-file` *                    | Disallows multiple Feature definitions in the same file    |
+| `up-to-one-background-per-file` *           | Disallows multiple Background definition in the same file  |
+| &nbsp;                                      |                                                            |
+| [`indentation`](#indentation)               | Allows the user to specify indentation rules               |
+| [`new-line-at-eof`](#new-line-at-eof)       | Disallows/enforces new line at EOF                         |
+| `no-dupe-feature-names`                     | Disallows duplicate Feature names                          |
+| `no-dupe-scenario-names`                    | Disallows duplicate Scenario names                         |
+| `no-empty-file`                             | Disallows empty feature files                              |
+| `no-files-without-scenarios`                | Disallows files with no scenarios                          |
+| `no-multiple-empty-lines`                   | Disallows multiple empty lines                             |
+| `no-partially-commented-tag-lines`          | Disallows partially commented tag lines                    |
+| [`no-restricted-tags`](#no-restricted-tags) | Disallow use of particular @tags                           |
+| `no-scenario-outlines-without-examples`     | Disallows scenario outlines without examples               |
+| `no-trailing-spaces`                        | Disallows trailing spaces                                  |
+| `no-unnamed-features`                       | Disallows empty Feature name                               |
+| `no-unnamed-scenarios`                      | Disallows empty Scenario name                              |
+| `use-and`                                   | Disallows repeated step names requiring use of And instead |
 
 \* These rules cannot be turned off because they detect undocumented cucumber functionality that causes the [gherkin](https://github.com/cucumber/gherkin-javascript) parser to crash.
 

--- a/README.md
+++ b/README.md
@@ -24,25 +24,25 @@ Or check this:
 
 ## Available rules
 
-| Name                                    | Functionality                                             | Configurable |
-|-----------------------------------------|-----------------------------------------------------------|:------------:|
-| `no-tags-on-backgrounds`                | Disallows tags on Background                              | no*          |
-| `one-feature-per-file`                  | Disallows multiple Feature definitions in the same file   | no*          |
-| `up-to-one-background-per-file`         | Disallows multiple Background definition in the same file | no*          |
-| `indentation`                           | Allows the user to specify indentation rules              | yes          |
-| `new-line-at-eof`                       | Disallows/enforces new line at EOF                        | yes          |
-| `no-dupe-feature-names`                 | Disallows duplicate Feature names                         | yes          |
-| `no-dupe-scenario-names`                | Disallows duplicate Scenario names                        | yes          |
-| `no-empty-file`                         | Disallows empty feature files                             | yes          |
-| `no-files-without-scenarios`            | Disallows files with no scenarios                         | yes          |
-| `no-multiple-empty-lines`               | Disallows multiple empty lines                            | yes          |
-| `no-partially-commented-tag-lines`      | Disallows partially commented tag lines                   | yes          |
-| `no-restricted-tags`                    | Disallow use of particular @tags                          | yes          |
-| `no-scenario-outlines-without-examples` | Disallows scenario outlines without examples              | yes          |
-| `no-trailing-spaces`                    | Disallows trailing spaces                                 | yes          |
-| `no-unnamed-features`                   | Disallows empty Feature name                              | yes          |
-| `no-unnamed-scenarios`                  | Disallows empty Scenario name                             | yes          |
-| `use-and`                               | Disallows repeated step names requiring use of And instead| yes          |
+| Name                                    | Functionality                                             |
+|-----------------------------------------|-----------------------------------------------------------|
+| `no-tags-on-backgrounds` *              | Disallows tags on Background                              |
+| `one-feature-per-file` *                | Disallows multiple Feature definitions in the same file   |
+| `up-to-one-background-per-file` *       | Disallows multiple Background definition in the same file |
+| `indentation`                           | Allows the user to specify indentation rules              |
+| `new-line-at-eof`                       | Disallows/enforces new line at EOF                        |
+| `no-dupe-feature-names`                 | Disallows duplicate Feature names                         |
+| `no-dupe-scenario-names`                | Disallows duplicate Scenario names                        |
+| `no-empty-file`                         | Disallows empty feature files                             |
+| `no-files-without-scenarios`            | Disallows files with no scenarios                         |
+| `no-multiple-empty-lines`               | Disallows multiple empty lines                            |
+| `no-partially-commented-tag-lines`      | Disallows partially commented tag lines                   |
+| `no-restricted-tags`                    | Disallow use of particular @tags                          |
+| `no-scenario-outlines-without-examples` | Disallows scenario outlines without examples              |
+| `no-trailing-spaces`                    | Disallows trailing spaces                                 |
+| `no-unnamed-features`                   | Disallows empty Feature name                              |
+| `no-unnamed-scenarios`                  | Disallows empty Scenario name                             |
+| `use-and`                               | Disallows repeated step names requiring use of And instead|
 
 \* These rules cannot be turned off because they detect undocumented cucumber functionality that causes the [gherkin](https://github.com/cucumber/gherkin-javascript) parser to crash.
 

--- a/README.md
+++ b/README.md
@@ -30,18 +30,18 @@ Or check this:
 | `one-feature-per-file`                  | Disallows multiple Feature definitions in the same file   | no*          |
 | `up-to-one-background-per-file`         | Disallows multiple Background definition in the same file | no*          |
 | `indentation`                           | Allows the user to specify indentation rules              | yes          |
+| `new-line-at-eof`                       | Disallows/enforces new line at EOF                        | yes          |
 | `no-dupe-feature-names`                 | Disallows duplicate Feature names                         | yes          |
 | `no-dupe-scenario-names`                | Disallows duplicate Scenario names                        | yes          |
 | `no-empty-file`                         | Disallows empty feature files                             | yes          |
 | `no-files-without-scenarios`            | Disallows files with no scenarios                         | yes          |
 | `no-multiple-empty-lines`               | Disallows multiple empty lines                            | yes          |
 | `no-partially-commented-tag-lines`      | Disallows partially commented tag lines                   | yes          |
+| `no-restricted-tags`                    | Disallow use of particular @tags                          | yes          |
+| `no-scenario-outlines-without-examples` | Disallows scenario outlines without examples              | yes          |
 | `no-trailing-spaces`                    | Disallows trailing spaces                                 | yes          |
 | `no-unnamed-features`                   | Disallows empty Feature name                              | yes          |
 | `no-unnamed-scenarios`                  | Disallows empty Scenario name                             | yes          |
-| `new-line-at-eof`                       | Disallows/enforces new line at EOF                        | yes          |
-| `no-scenario-outlines-without-examples` | Disallows scenario outlines without examples              | yes          |
-| `no-restricted-tags`                    | Disallow use of particular @tags                          | yes          |
 | `use-and`                               | Disallows repeated step names requiring use of And instead| yes          |
 
 \* These rules cannot be turned off because they detect undocumented cucumber functionality that causes the [gherkin](https://github.com/cucumber/gherkin-javascript) parser to crash.

--- a/README.md
+++ b/README.md
@@ -29,6 +29,7 @@ Or check this:
 | `no-tags-on-backgrounds` *              | Disallows tags on Background                              |
 | `one-feature-per-file` *                | Disallows multiple Feature definitions in the same file   |
 | `up-to-one-background-per-file` *       | Disallows multiple Background definition in the same file |
+| &nbsp;                                  |                                                           |
 | `indentation`                           | Allows the user to specify indentation rules              |
 | `new-line-at-eof`                       | Disallows/enforces new line at EOF                        |
 | `no-dupe-feature-names`                 | Disallows duplicate Feature names                         |

--- a/README.md
+++ b/README.md
@@ -41,6 +41,7 @@ Or check this:
 | `no-unnamed-scenarios`                  | Disallows empty Scenario name                             | yes          |
 | `new-line-at-eof`                       | Disallows/enforces new line at EOF                        | yes          |
 | `no-scenario-outlines-without-examples` | Disallows scenario outlines without examples              | yes          |
+| `no-restricted-tags`                    | Disallow use of particular @tags                          | yes          |
 | `use-and`                               | Disallows repeated step names requiring use of And instead| yes          |
 
 \* These rules cannot be turned off because they detect undocumented cucumber functionality that causes the [gherkin](https://github.com/cucumber/gherkin-javascript) parser to crash.
@@ -80,6 +81,14 @@ This feature is able to handle all localizations of the gherkin steps.
 ```
 {
   "new-line-at-eof": ["on", "no"]
+}
+```
+
+`no-restricted-tags` must be configured with list of tags for it to have any effect:
+
+```
+{
+  "no-restricted-tags": ["on", {"tags": ["@watch", "@wip", "@todo"]}]
 }
 ```
 

--- a/README.md
+++ b/README.md
@@ -31,6 +31,7 @@ Or check this:
 | `up-to-one-background-per-file` *           | Disallows multiple Background definition in the same file  |
 | &nbsp;                                      |                                                            |
 | [`indentation`](#indentation)               | Allows the user to specify indentation rules               |
+| [`name-length`](#name-length)               | Allows restricting length of Feature/Scenario/Step names   |
 | [`new-line-at-eof`](#new-line-at-eof)       | Disallows/enforces new line at EOF                         |
 | `no-dupe-feature-names`                     | Disallows duplicate Feature names                          |
 | `no-dupe-scenario-names`                    | Disallows duplicate Scenario names                         |
@@ -70,6 +71,17 @@ This feature is able to handle all localizations of the gherkin steps.
 ```
 {
   "indentation" : ["on", { "Feature": 0, "Background": 0, "Scenario": 0, "Step": 2, "given": 2, "and": 3 }]
+}
+```
+
+## `name-length`
+
+`name-length` can be configured separately for Feature, Scenario and Step names.
+The default is 70 characters for each of these:
+
+```
+{
+  "name-length" : ["on", { "Feature": 70, "Scenario": 70, "Step": 70 }]
 }
 ```
 

--- a/README.md
+++ b/README.md
@@ -30,15 +30,15 @@ Or check this:
 | `one-feature-per-file` *                | Disallows multiple Feature definitions in the same file   |
 | `up-to-one-background-per-file` *       | Disallows multiple Background definition in the same file |
 | &nbsp;                                  |                                                           |
-| `indentation`                           | Allows the user to specify indentation rules              |
-| `new-line-at-eof`                       | Disallows/enforces new line at EOF                        |
+| [`indentation`](#indentation)           | Allows the user to specify indentation rules              |
+| [`new-line-at-eof`](#new-line-at-eof)   | Disallows/enforces new line at EOF                        |
 | `no-dupe-feature-names`                 | Disallows duplicate Feature names                         |
 | `no-dupe-scenario-names`                | Disallows duplicate Scenario names                        |
 | `no-empty-file`                         | Disallows empty feature files                             |
 | `no-files-without-scenarios`            | Disallows files with no scenarios                         |
 | `no-multiple-empty-lines`               | Disallows multiple empty lines                            |
 | `no-partially-commented-tag-lines`      | Disallows partially commented tag lines                   |
-| `no-restricted-tags`                    | Disallow use of particular @tags                          |
+| [`no-restricted-tags`](#no-restricted-tags) | Disallow use of particular @tags                          |
 | `no-scenario-outlines-without-examples` | Disallows scenario outlines without examples              |
 | `no-trailing-spaces`                    | Disallows trailing spaces                                 |
 | `no-unnamed-features`                   | Disallows empty Feature name                              |
@@ -58,6 +58,8 @@ The configurable rules are off by default. To turn them on, you will need to cre
 ```
 will turn on the `no-unnamed-features` rule.
 
+### `indentation`
+
 `indentation` can be configured in a more granular level and uses following rules by default:
 - Expected indentation for Feature, Background, Scenario: 0 spaces
 - Expected indentation for Steps: 2 spaces
@@ -70,6 +72,8 @@ This feature is able to handle all localizations of the gherkin steps.
   "indentation" : ["on", { "Feature": 0, "Background": 0, "Scenario": 0, "Step": 2, "given": 2, "and": 3 }]
 }
 ```
+
+### `new-line-at-eof`
 
 `new-line-at-eof` can also be configured to enforcing or disallowing new lines at EOF.
 - To enforce new lines at EOF:
@@ -84,6 +88,8 @@ This feature is able to handle all localizations of the gherkin steps.
   "new-line-at-eof": ["on", "no"]
 }
 ```
+
+### `no-restricted-tags`
 
 `no-restricted-tags` must be configured with list of tags for it to have any effect:
 


### PR DESCRIPTION
Also tried to improve the rules list in README overall:

- Sorted the rules alphabetically.
- Removed "Configurable" column, leaving just `*` marks for non-configurable rules.
- Separated the two groups of rules by empty row.
- Linked the rules with config options to the specific section in README.

Would be nice to have a separate pages for each rule where each would be fully documented with some example code, like done in ESLint docs.

PS. Could you also do a release. I'd really like to put this `no-restricted-tags` into use.