### PR TITLE
Document that feature files need to be specified

### DIFF
--- a/src/main.js
+++ b/src/main.js
@@ -10,6 +10,7 @@ function list(val) {
 }
 
 program
+  .usage('[options] <feature-files>')
   .option('-f, --format [format]', 'output format. Defaults to stylish')
   .option('-i, --ignore <...>', 'comma seperated list of files/glob patterns that the linter should ignore, overrides ' + featureFinder.defaultIgnoreFileName + ' file', list)
   .option('-c, --config [config]', 'configuration file, defaults to ' + configParser.defaultConfigFileName)


### PR DESCRIPTION
Previously running `gherkin-lint -h` printed this:

    Usage: gherkin-lint [options]

This made me think that the linter somehow searches for
the *.feature files by itself.  Took me a while to figure out
that they actually need to be specified from command line.
After this change, the usage info is:

    Usage: gherkin-lint [options] <feature-files>