### PR TITLE
Allow custom rules directories

### DIFF
--- a/README.md
+++ b/README.md
@@ -126,4 +126,11 @@ There are 2 ways you can specify files that the linter should ignore:
 
 ## Custom rules
 You can specify one more more custom rules directories by using the `-r` or `--rulesdir` command line option. Rules in the given directories will be available additionally to the default rules.
-Have a look at the `src/rules/` directory for examples, the `no-empty-file` rule is a good example to start with.
+
+Example:
+```
+gherkin-lint --rulesdir "/path/to/my/rulesdir" --rulesdir "from/cwd/rulesdir"
+```
+
+Paths can either be absolute or relative to the current working directory.
+Have a look at the `src/rules/` directory for examples; the `no-empty-file` rule is a good example to start with.

--- a/README.md
+++ b/README.md
@@ -122,3 +122,8 @@ You can find an example configuration file, that turns on all of the rules in th
 There are 2 ways you can specify files that the linter should ignore:
 1. Add a `.gherkin-lintignore` file in your working directory and specify one glob pattern per file line
 1. Use the command line option`-i` or `--ignore`,  pass in a comma separated list of glob patterns. If specified, the command line option will override the `.gherkin-lintignore` file.
+
+
+## Custom rules
+You can specify one more more custom rules directories by using the `-r` or `--rulesdir` command line option. Rules in the given directories will be available additionally to the default rules.
+Have a look at the `src/rules/` directory for examples, the `no-empty-file` rule is a good example to start with.

--- a/README.md
+++ b/README.md
@@ -133,4 +133,4 @@ gherkin-lint --rulesdir "/path/to/my/rulesdir" --rulesdir "from/cwd/rulesdir"
 ```
 
 Paths can either be absolute or relative to the current working directory.
-Have a look at the `src/rules/` directory for examples; the `no-empty-file` rule is a good example to start with.
+Have a look at the `src/rules/` directory for examples; The `no-empty-file` rule is a good example to start with.

--- a/package.json
+++ b/package.json
@@ -18,6 +18,9 @@
     },
     {
       "name": "Giuseppe DiBella"
+    },
+    {
+      "name": "Joscha Feth"
     }
   ],
   "main": "src/main.js",

--- a/src/config-parser.js
+++ b/src/config-parser.js
@@ -4,7 +4,7 @@ var rules = require('./rules.js');
 var defaultConfigFileName = '.gherkin-lintrc';
 var errors;
 
-function getConfiguration(configPath) {
+function getConfiguration(configPath, additionalRulesDirs) {
   errors = [];
   if (configPath) {
     if (!fs.existsSync(configPath)) {
@@ -19,7 +19,7 @@ function getConfiguration(configPath) {
   }
   var config = JSON.parse(fs.readFileSync(configPath));
 
-  verifyConfigurationFile(config);
+  verifyConfigurationFile(config, additionalRulesDirs);
 
   if (errors.length > 0) {
     console.error('\x1b[31m\x1b[1mError(s) in configuration file:\x1b[0m');  // eslint-disable-line no-console
@@ -32,9 +32,9 @@ function getConfiguration(configPath) {
   return config;
 }
 
-function verifyConfigurationFile(config) {
+function verifyConfigurationFile(config, additionalRulesDirs) {
   for (var rule in config) {
-    if (!rules.doesRuleExist(rule)) {
+    if (!rules.doesRuleExist(rule, additionalRulesDirs)) {
       errors.push('Rule "' + rule + '" does not exist');
     } else {
       verifyRuleConfiguration(rule, config[rule]);

--- a/src/linter.js
+++ b/src/linter.js
@@ -4,7 +4,7 @@ var Gherkin = require('gherkin');
 var parser = new Gherkin.Parser();
 var rules = require('./rules.js');
 
-function lint(files, configuration) {
+function lint(files, configuration, additionalRulesDirs) {
   var output = [];
 
   files.forEach(function(fileName) {
@@ -17,7 +17,7 @@ function lint(files, configuration) {
     var errors = [];
     try {
       var feature = parser.parse(fileContent).feature || {};
-      errors = rules.runAllEnabledRules(feature, file, configuration);
+      errors = rules.runAllEnabledRules(feature, file, configuration, additionalRulesDirs);
     } catch(e) {
       if(e.errors) {
         errors = processFatalErrors(e.errors);

--- a/src/main.js
+++ b/src/main.js
@@ -9,16 +9,23 @@ function list(val) {
   return val.split(',');
 }
 
+function collect(val, memo) {
+  memo.push(val);
+  return memo;
+}
+
 program
   .usage('[options] <feature-files>')
   .option('-f, --format [format]', 'output format. Defaults to stylish')
   .option('-i, --ignore <...>', 'comma seperated list of files/glob patterns that the linter should ignore, overrides ' + featureFinder.defaultIgnoreFileName + ' file', list)
   .option('-c, --config [config]', 'configuration file, defaults to ' + configParser.defaultConfigFileName)
+  .option('-r, --rulesdir <...>', 'additional rule directories', collect, [])
   .parse(process.argv);
 
+var additionalRulesDirs = program.rulesdir;
 var files = featureFinder.getFeatureFiles(program.args, program.ignore);
-var config = configParser.getConfiguration(program.config);
-var results = linter.lint(files, config);
+var config = configParser.getConfiguration(program.config, additionalRulesDirs);
+var results = linter.lint(files, config, additionalRulesDirs);
 printResults(results, program.format);
 process.exit(getExitCode(results));
 

--- a/src/rules.js
+++ b/src/rules.js
@@ -9,6 +9,7 @@ function getAllRules(additionalRulesDirs) {
     path.join(__dirname, 'rules')
   ].concat(additionalRulesDirs || []);
   rulesDirs.forEach(function(rulesDir) {
+    rulesDir = path.resolve(rulesDir);
     fs.readdirSync(rulesDir).forEach(function(file) {
       var rule = require(path.join(rulesDir, file));
       rules[rule.name] = rule;

--- a/src/rules.js
+++ b/src/rules.js
@@ -2,25 +2,27 @@
 
 var fs = require('fs');
 var path = require('path');
-var rules; // Cashing list of rules, so that we only load them once
 
-function getAllRules() {
-  if (!rules) {
-    rules = {};
-    fs.readdirSync(path.join(__dirname, 'rules')).forEach(function(file) {
-      var ruleName = file.replace(/\.js$/, '');
-      rules[ruleName] = require(path.join(__dirname, 'rules', file));
+function getAllRules(additionalRulesDirs) {
+  var rules = {};
+  var rulesDirs = [
+    path.join(__dirname, 'rules')
+  ].concat(additionalRulesDirs || []);
+  rulesDirs.forEach(function(rulesDir) {
+    fs.readdirSync(rulesDir).forEach(function(file) {
+      var rule = require(path.join(rulesDir, file));
+      rules[rule.name] = rule;
     });
-  }
+  });
   return rules;
 }
 
-function getRule(rule) {
-  return getAllRules()[rule];
+function getRule(rule, additionalRulesDirs) {
+  return getAllRules(additionalRulesDirs)[rule];
 }
 
-function doesRuleExist(rule) {
-  return getRule(rule) !== undefined;
+function doesRuleExist(rule, additionalRulesDirs) {
+  return getRule(rule, additionalRulesDirs) !== undefined;
 }
 
 function isRuleEnabled(ruleConfig) {
@@ -30,10 +32,10 @@ function isRuleEnabled(ruleConfig) {
   return ruleConfig === 'on';
 }
 
-function runAllEnabledRules(feature, file, configuration) {
+function runAllEnabledRules(feature, file, configuration, additionalRulesDirs) {
   var errors = [];
   var ignoreFutureErrors = false;
-  var rules = getAllRules();
+  var rules = getAllRules(additionalRulesDirs);
   Object.keys(rules).forEach(function(ruleName) {
     var rule = rules[ruleName];
     if (isRuleEnabled(configuration[rule.name]) && !ignoreFutureErrors) {

--- a/test/rulesdir/.gherkin-lintrc
+++ b/test/rulesdir/.gherkin-lintrc
@@ -1,0 +1,5 @@
+{
+  "indentation": "on",
+  "custom" : "on",
+  "another-custom" : "on"
+}

--- a/test/rulesdir/other_rules/custom.js
+++ b/test/rulesdir/other_rules/custom.js
@@ -1,0 +1,17 @@
+var rule = 'another-custom';
+
+function custom() {
+  return [
+    {
+      message: 'Another custom error',
+      rule   : rule,
+      line   : 456
+    }
+  ];
+}
+
+module.exports = {
+  name: rule,
+  run: custom,
+  availableConfigs: []
+};

--- a/test/rulesdir/rules/custom.js
+++ b/test/rulesdir/rules/custom.js
@@ -1,0 +1,17 @@
+var rule = 'custom';
+
+function custom() {
+  return [
+    {
+      message: 'Custom error',
+      rule   : rule,
+      line   : 123
+    }
+  ];
+}
+
+module.exports = {
+  name: rule,
+  run: custom,
+  availableConfigs: []
+};

--- a/test/rulesdir/rulesdir.js
+++ b/test/rulesdir/rulesdir.js
@@ -6,8 +6,8 @@ var configParser = require('../../src/config-parser');
 describe('rulesdir CLI option', function() {
   it('loads additional rules from specified directories', function() {
     var additionalRulesDirs = [
-      path.join(__dirname, 'rules'),
-      path.join(__dirname, 'other_rules')
+      path.join(__dirname, 'rules'), // absolute path
+      path.join('test', 'rulesdir', 'other_rules') // relative path from root
     ];
     var config = configParser.getConfiguration(path.join(__dirname, '.gherkin-lintrc'), additionalRulesDirs);
     var featureFile = path.join(__dirname, 'simple.features');

--- a/test/rulesdir/rulesdir.js
+++ b/test/rulesdir/rulesdir.js
@@ -10,12 +10,17 @@ describe('rulesdir CLI option', function() {
       path.join(__dirname, 'other_rules')
     ];
     var config = configParser.getConfiguration(path.join(__dirname, '.gherkin-lintrc'), additionalRulesDirs);
-    var featureFile = path.join(__dirname, 'empty.features');
+    var featureFile = path.join(__dirname, 'simple.features');
     var results = linter.lint([ featureFile ], config, additionalRulesDirs);
 
     expect(results).to.deep.equal([
       {
         errors: [
+          { // This one is to make sure we don't accidentally regress and always load the default rules
+            line: 1,
+            message: 'Wrong indentation for "Feature", expected indentation level of 0, but got 4',
+            rule: 'indentation'
+          },
           {
             line: 123,
             message: 'Custom error',

--- a/test/rulesdir/rulesdir.js
+++ b/test/rulesdir/rulesdir.js
@@ -1,0 +1,34 @@
+var path = require('path');
+var expect = require('chai').expect;
+var linter = require('../../src/linter');
+var configParser = require('../../src/config-parser');
+
+describe('rulesdir CLI option', function() {
+  it('loads additional rules from specified directories', function() {
+    var additionalRulesDirs = [
+      path.join(__dirname, 'rules'),
+      path.join(__dirname, 'other_rules')
+    ];
+    var config = configParser.getConfiguration(path.join(__dirname, '.gherkin-lintrc'), additionalRulesDirs);
+    var featureFile = path.join(__dirname, 'empty.features');
+    var results = linter.lint([ featureFile ], config, additionalRulesDirs);
+
+    expect(results).to.deep.equal([
+      {
+        errors: [
+          {
+            line: 123,
+            message: 'Custom error',
+            rule: 'custom'
+          },
+          {
+            line: 456,
+            message: 'Another custom error',
+            rule: 'another-custom'
+          }
+        ],
+        filePath: featureFile
+      }
+    ]);
+  });
+});

--- a/test/rulesdir/simple.features
+++ b/test/rulesdir/simple.features
@@ -1,0 +1,1 @@
+    Feature: not much here, except for wrong indentation


### PR DESCRIPTION
This allows passing custom rules directories, similar to the [eslint --rulesdir option](http://eslint.org/docs/user-guide/command-line-interface#--rulesdir) that will be searched for rules.

Fixes #70 