### PR TITLE
fix: do not pick up duplicates

### DIFF
--- a/src/feature-finder.js
+++ b/src/feature-finder.js
@@ -1,3 +1,4 @@
+var _ = require('lodash');
 var glob = require('glob');
 var fs = require('fs');
 var path = require('path');
@@ -35,7 +36,7 @@ function getFeatureFiles(args, ignoreArg) {
     var globOptions = {ignore: getIgnorePatterns(ignoreArg)};
     files = files.concat(glob.sync(fixedPattern, globOptions));
   });
-  return files;
+  return _.uniq(files);
 }
 
 function getIgnorePatterns(ignoreArg) {

--- a/test/configuration-parser/test.js
+++ b/test/configuration-parser/test.js
@@ -3,7 +3,7 @@ var expect = require('chai').expect;
 var configParser = require('../../src/config-parser.js');
 var expectedResults = require('./test-results/results.js');
 
-require('mocha-sinon');
+require('mocha-sinon')();
 
 describe('Configuration file', function() {
   describe('parsing/verification is successful when', function() {
@@ -27,8 +27,13 @@ describe('Configuration file', function() {
   });
 
   describe('parsing/verification throws an error when the config contains', function() {
+    var stub;
     beforeEach(function() {
-      this.sinon.stub(console, 'error');
+      stub = this.sinon.stub(console, 'error');
+    });
+
+    afterEach(function() {
+      stub.restore();
     });
 
     it('a non existing rule', function() {

--- a/test/feature-finder/test.js
+++ b/test/feature-finder/test.js
@@ -1,13 +1,11 @@
-var path = require('path');
 var assert = require('chai').assert;
-var expect = require('chai').expect;
 var featureFinder = require('../../src/feature-finder.js');
 
 describe('Feature finder', function() {
   it('does not return duplicates', function() {
     var actual = featureFinder.getFeatureFiles([
       'test/feature-finder/fixtures',
-      'test/feature-finder',
+      'test/feature-finder'
     ]);
     assert.deepEqual(actual, ['test/feature-finder/fixtures/a.feature']);
   });

--- a/test/feature-finder/test.js
+++ b/test/feature-finder/test.js
@@ -1,0 +1,14 @@
+var path = require('path');
+var assert = require('chai').assert;
+var expect = require('chai').expect;
+var featureFinder = require('../../src/feature-finder.js');
+
+describe('Feature finder', function() {
+  it('does not return duplicates', function() {
+    var actual = featureFinder.getFeatureFiles([
+      'test/feature-finder/fixtures',
+      'test/feature-finder',
+    ]);
+    assert.deepEqual(actual, ['test/feature-finder/fixtures/a.feature']);
+  });
+});


### PR DESCRIPTION
Currently, it is possible to get errors (for example for unique scenario names) by passing something like: `gherkin-lint src src/x.feature` - `x.feature` would be picked up twice and then error.
This PR fixes this.

cc @brendanAnnable