### PR TITLE
Add understandable message for when you add 'Examples' to a Scenario

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,6 +31,7 @@ Or check this:
 | `one-feature-per-file` *                    | Disallows multiple Feature definitions in the same file                                  |
 | `up-to-one-background-per-file` *           | Disallows multiple Background definition in the same file                                |
 | `no-multiline-steps` *                      | Disallows mutiline Steps                                                                 |
+| `no-examples-in-scenarios`                  | Disallow the use of "Examples" in scenarios                                              |
 | &nbsp;                                      |                                                                                          |
 | [`indentation`](#indentation)               | Allows the user to specify indentation rules                                             |
 | [`name-length`](#name-length)               | Allows restricting length of Feature/Scenario/Step names                                 |

--- a/src/linter.js
+++ b/src/linter.js
@@ -79,6 +79,9 @@ function getFormattedFatalError(error) {
   } else if(error.message.indexOf('got \'Feature') > -1) {
     errorMsg = 'Multiple "Feature" definitions in the same file are disallowed';
     rule = 'one-feature-per-file';
+  } else if (error.message.indexOf('expected: #EOF, #TableRow, #DocStringSeparator, #StepLine, #TagLine, #ScenarioLine, #ScenarioOutlineLine, #Comment, #Empty, got \'Examples:\'') > -1) {
+    errorMsg = 'Cannot use "Examples" in a "Scenario", use a "Scenario Outline" instead';
+    rule = 'no-examples-in-scenarios';
   } else if (error.message.indexOf('expected: #EOF, #TableRow, #DocStringSeparator, #StepLine, #TagLine, #ScenarioLine, #ScenarioOutlineLine, #Comment, #Empty, got') > -1 ||
              error.message.indexOf('expected: #EOF, #TableRow, #DocStringSeparator, #StepLine, #TagLine, #ExamplesLine, #ScenarioLine, #ScenarioOutlineLine, #Comment, #Empty, got') > -1) {
     errorMsg = 'Steps should begin with "Given", "When", "Then", "And" or "But". Multiline steps are dissallowed';

--- a/test/linter/ExampleInScenario.feature
+++ b/test/linter/ExampleInScenario.feature
@@ -1,0 +1,8 @@
+Feature: This is a feature with example on a scenario
+
+Scenario: This is a scenario with an example
+ Given I do this
+
+Examples:
+ |a|
+ |1|

--- a/test/linter/linter.js
+++ b/test/linter/linter.js
@@ -70,4 +70,16 @@ describe('Linter', function() {
     assert.lengthOf(actual, 1);
     assert.deepEqual(actual[0].errors, expected);
   });
+
+  it('detects no-examples-in-scenarios violations', function() {
+    var actual = linter.lint(['test/linter/ExampleInScenario.feature']);
+    //console.log(actual)
+    var expected = [{
+      'line': '6',
+      'message': 'Cannot use "Examples" in a "Scenario", use a "Scenario Outline" instead',
+      'rule': 'no-examples-in-scenarios'
+    }];
+    assert.lengthOf(actual, 1);
+    assert.deepEqual(actual[0].errors, expected);
+  });
 });


### PR DESCRIPTION
Fixes #43 