### PR TITLE
Issue #109

### DIFF
--- a/src/config-verifier.js
+++ b/src/config-verifier.js
@@ -6,13 +6,13 @@ function verifyConfigurationFile(config, additionalRulesDirs) {
     if (!rules.doesRuleExist(rule, additionalRulesDirs)) {
       errors.push('Rule "' + rule + '" does not exist');
     } else {
-      verifyRuleConfiguration(rule, config[rule], errors);
+      verifyRuleConfiguration(rule, config[rule], additionalRulesDirs, errors);
     }
   }
   return errors;
 }
 
-function verifyRuleConfiguration(rule, ruleConfig, errors) {
+function verifyRuleConfiguration(rule, ruleConfig, additionalRulesDirs, errors) {
   var enablingSettings = ['on', 'off'];
   var genericErrorMsg = 'Invalid rule configuration for "' + rule + '" - ';
 
@@ -25,20 +25,20 @@ function verifyRuleConfiguration(rule, ruleConfig, errors) {
       errors.push(genericErrorMsg + ' The config should only have 2 parts.');
     }
 
-    var ruleObj = rules.getRule(rule);
+    var ruleObj = rules.getRule(rule, additionalRulesDirs);
     var isValidSubConfig;
 
     if (typeof(ruleConfig[1]) === 'string') {
       isValidSubConfig = function(availableConfigs, subConfig) {
         return ruleObj.availableConfigs.indexOf(subConfig) > -1;
       };
-      testSubconfig(genericErrorMsg, rule, ruleConfig[1], isValidSubConfig, errors);
+      testSubconfig(genericErrorMsg, rule, ruleConfig[1], isValidSubConfig, additionalRulesDirs, errors);
     } else {
       isValidSubConfig = function(availableConfigs, subConfig) {
         return ruleObj.availableConfigs[subConfig] !== undefined;
       };
       for (var subConfig in ruleConfig[1]) {
-        testSubconfig(genericErrorMsg, rule, subConfig, isValidSubConfig, errors);
+        testSubconfig(genericErrorMsg, rule, subConfig, isValidSubConfig, additionalRulesDirs, errors);
       }
     }
   } else {
@@ -48,8 +48,8 @@ function verifyRuleConfiguration(rule, ruleConfig, errors) {
   }
 }
 
-function testSubconfig(genericErrorMsg, rule, subConfig, isValidSubConfig, errors) {
-  var ruleObj = rules.getRule(rule);
+function testSubconfig(genericErrorMsg, rule, subConfig, isValidSubConfig, additionalRulesDirs, errors) {
+  var ruleObj = rules.getRule(rule, additionalRulesDirs);
   if (!isValidSubConfig(ruleObj.availableConfigs, subConfig)) {
     errors.push(genericErrorMsg + ' The rule does not have the specified configuration option "' + subConfig + '"');
   }

--- a/test/rulesdir/.gherkin-lintrc
+++ b/test/rulesdir/.gherkin-lintrc
@@ -1,5 +1,6 @@
 {
   "indentation": "on",
   "custom" : "on",
-  "another-custom" : "on"
+  "another-custom" : "on",
+  "another-custom-list" : ["on", {"element": ["first_element"]}]
 }

--- a/test/rulesdir/other_rules/custom-list.js
+++ b/test/rulesdir/other_rules/custom-list.js
@@ -1,0 +1,20 @@
+var rule = 'another-custom-list';
+var availableConfigs = {
+  'element': []
+};
+
+function custom() {
+  return [
+    {
+      message: 'Another custom-list error',
+      rule   : rule,
+      line   : 109
+    }
+  ];
+}
+
+module.exports = {
+  name: rule,
+  run: custom,
+  availableConfigs: availableConfigs
+};

--- a/test/rulesdir/rulesdir.js
+++ b/test/rulesdir/rulesdir.js
@@ -22,6 +22,11 @@ describe('rulesdir CLI option', function() {
             rule: 'indentation'
           },
           {
+            line: 109,
+            message: 'Another custom-list error',
+            rule: 'another-custom-list'
+          },
+          {
             line: 123,
             message: 'Custom error',
             rule: 'custom'


### PR DESCRIPTION
I have been creating a new rule to check if a step have some key words and I have some problem launching this rule.

It seems that in the gherkin-lint/src/config-verifier.js file, when calling the getRule method, the additionalRulesDirs (which contains the path to my own rules) is not specified.

To fix it, it's needed to add the additionalRulesDirs parameter in all the getRule method calls, which implies add the parameter to verifyRuleConfiguration and testSubconfig method.

Included fix and test to check that the avalaible config is allowed in the custom rules