### PR TITLE
Create required-tags.js

### DIFF
--- a/src/rules/required-tags.js
+++ b/src/rules/required-tags.js
@@ -1,0 +1,37 @@
+const rule = 'required-tags';
+const availableConfigs = {
+  tags: []
+};
+
+const checkTagExists = (requiredTag, scenarioTags) => {
+  const result = scenarioTags.length == 0
+    || scenarioTags.some((tagObj) => RegExp(requiredTag).test(tagObj.name));
+  if (!result) {
+    const lines = Array.from(new Set(scenarioTags.map((tag) => tag.location.line)));
+    return {
+      message: `No tag found matching: ${requiredTag}`,
+      rule,
+      line: lines.join(',')
+    }
+  }
+  return result;
+};
+
+const checkRequiredTagsExistInScenarios = (feature, file, config) => {
+  let errors = [];
+  feature.children.forEach((scenario) => {
+    // Check each Scenario for the required tags
+    const requiredTagErrors = config.tags.map((requiredTag) => {
+      return checkTagExists(requiredTag, scenario.tags || []);
+    }).filter((item) => typeof item === 'object' && item.message);
+    // Update errors
+    errors = errors.concat(requiredTagErrors);
+  });
+  return errors;
+};
+
+module.exports = {
+  name: rule,
+  run: checkRequiredTagsExistInScenarios,
+  availableConfigs
+}

--- a/src/rules/required-tags.js
+++ b/src/rules/required-tags.js
@@ -12,7 +12,7 @@ const checkTagExists = (requiredTag, scenarioTags) => {
       message: `No tag found matching: ${requiredTag}`,
       rule,
       line: lines.join(',')
-    }
+    };
   }
   return result;
 };
@@ -34,4 +34,4 @@ module.exports = {
   name: rule,
   run: checkRequiredTagsExistInScenarios,
   availableConfigs
-}
+};

--- a/src/rules/required-tags.js
+++ b/src/rules/required-tags.js
@@ -7,12 +7,17 @@ const checkTagExists = (requiredTag, scenarioTags) => {
   const result = scenarioTags.length == 0
     || scenarioTags.some((tagObj) => RegExp(requiredTag).test(tagObj.name));
   if (!result) {
-    const lines = Array.from(new Set(scenarioTags.map((tag) => tag.location.line)));
+    const lines = [];
+    scenarioTags.forEach((tag) => {
+      if (lines.indexOf(tag.location.line) === -1) {
+        lines.push(tag.location.line);
+      }
+    });
     return {
       message: `No tag found matching: ${requiredTag}`,
       rule,
       line: lines.join(',')
-    };
+    }
   }
   return result;
 };

--- a/src/rules/required-tags.js
+++ b/src/rules/required-tags.js
@@ -17,7 +17,7 @@ const checkTagExists = (requiredTag, scenarioTags) => {
       message: `No tag found matching: ${requiredTag}`,
       rule,
       line: lines.join(',')
-    }
+    };
   }
   return result;
 };


### PR DESCRIPTION
Add optional configurable required-tags rule. Accepts an array of required tags, either as plain strings or escaped regular expressions.