### PR TITLE
Fix bugs related to empty examples tables

### DIFF
--- a/src/rules/indentation.js
+++ b/src/rules/indentation.js
@@ -61,10 +61,12 @@ function testFeature(feature, configuration, mergedConfiguration) {
     test(scenarioOutline.location, 'Scenario');
     scenarioOutline.examples.forEach(function(examples) {
       test(examples.location, 'Examples');
-      test(examples.tableHeader.location, 'example');
-      examples.tableBody.forEach(function(row) {
-        test(row.location, 'example');
-      });
+      if (examples.tableHeader) {
+        test(examples.tableHeader.location, 'example');
+        examples.tableBody.forEach(function(row) {
+          test(row.location, 'example');
+        });
+      }
     });
   }
 

--- a/src/rules/no-scenario-outlines-without-examples.js
+++ b/src/rules/no-scenario-outlines-without-examples.js
@@ -1,10 +1,12 @@
+var _ = require('lodash');
 var rule = 'no-scenario-outlines-without-examples';
 
 function noScenarioOutlinesWithoutExamples(feature) {
   if (feature.children) {
     var errors = [];
+
     feature.children.forEach(function(scenario) {
-      if (scenario.type === 'ScenarioOutline' && !scenario.examples.length) {
+      if (scenario.type === 'ScenarioOutline' && (!_.find(scenario.examples, 'tableBody') || !_.find(scenario.examples, 'tableBody')['tableBody'].length)) {
         errors.push({message: 'Scenario Outline does not have any Examples',
           rule   : rule,
           line   : scenario.location.line});

--- a/test/rules/no-scenario-outlines-without-examples/NoViolations.feature
+++ b/test/rules/no-scenario-outlines-without-examples/NoViolations.feature
@@ -1,0 +1,9 @@
+Feature: Test for no-scenario-outlines-without-examples rule
+
+Scenario Outline: Scenario Outline with examples
+  Given we use foo
+  And the scenario outline has examples
+  Then I should not see a no-scenario-outlines-without-examples error
+Examples:
+	|foo | bar|
+	|1 	 | 2  |

--- a/test/rules/no-scenario-outlines-without-examples/ViolationsEmptyExamples.feature
+++ b/test/rules/no-scenario-outlines-without-examples/ViolationsEmptyExamples.feature
@@ -1,0 +1,7 @@
+Feature: Test for no-scenario-outlines-without-examples rule
+
+Scenario Outline: Scenario Outline with empty examples
+  Given we use foo
+  And the scenario outline has empty examples
+  Then I should see a no-scenario-outlines-without-examples error
+Examples:

--- a/test/rules/no-scenario-outlines-without-examples/ViolationsNoExamples.feature
+++ b/test/rules/no-scenario-outlines-without-examples/ViolationsNoExamples.feature
@@ -4,8 +4,3 @@ Scenario Outline: Scenario Outline without examples
   Given we use foo
   And the scenario outline has no examples
   Then I should see a no-scenario-outlines-without-examples error
-
-Scenario: Scenario without examples
-  Given we use bar
-  And the scenario has no examples
-  Then I should see no no-scenario-outlines-without-examples error

--- a/test/rules/no-scenario-outlines-without-examples/ViolationsNoExamplesBody.feature
+++ b/test/rules/no-scenario-outlines-without-examples/ViolationsNoExamplesBody.feature
@@ -1,0 +1,8 @@
+Feature: Test for no-scenario-outlines-without-examples rule
+
+Scenario Outline: Scenario Outline with an examples header but no body
+  Given we use foo
+  And the scenario outline has an examples header but no body
+  Then I should see a no-scenario-outlines-without-examples error
+Examples:
+	|foo| bar|

--- a/test/rules/no-scenario-outlines-without-examples/no-scenario-outlines-without-examples.js
+++ b/test/rules/no-scenario-outlines-without-examples/no-scenario-outlines-without-examples.js
@@ -1,0 +1,28 @@
+var ruleTestBase = require('../rule-test-base');
+var rule = require('../../../dist/rules/no-scenario-outlines-without-examples.js');
+var runTest = ruleTestBase.createRuleTest(rule,
+  'Scenario Outline does not have any Examples');
+
+describe('No scenario outlines without examples rule', function() {
+  it('doesn\'t raise errors when there are no violations', function() {
+    runTest('no-scenario-outlines-without-examples/NoViolations.feature', {}, []);
+  });
+
+  it('detects errors for scenario outlines that are missing the "Examples" keyword completely', function() {
+    runTest('no-scenario-outlines-without-examples/ViolationsNoExamples.feature', {}, [ 
+      {line: 3}
+    ]);
+  });
+
+  it('detects errors for scenario outlines that have empty "Examples"', function() {
+    runTest('no-scenario-outlines-without-examples/ViolationsEmptyExamples.feature', {}, [ 
+      {line: 3}
+    ]);
+  });
+
+  it('detects errors for scenario outlines that define variable names but don\'t have any values to iterate over', function() {
+    runTest('no-scenario-outlines-without-examples/ViolationsNoExamplesBody.feature', {}, [ 
+      {line: 3}
+    ]);
+  });
+});


### PR DESCRIPTION
- Resolves #154
- Adds unit tests to `no-scenario-outlines-without-examples` rule
- Fixes crash in the indentation rule when an empty examples table is used