### PR TITLE
Fix no-homogenous-tags rule not working with examples

### DIFF
--- a/package.json
+++ b/package.json
@@ -91,7 +91,7 @@
   "scripts": {
     "build": "babel src -d dist",
     "coverage": "nyc report --reporter=text-lcov | coveralls",
-    "demo": "node ./dist/main.js . -c ./test-data-wip/.gherkin-lintrc",
+    "demo": "node ./dist/main.js -c ./test-data-wip/.gherkin-lintrc test-data-wip/**",
     "lint": "eslint ./src ./test",
     "mocha": "mocha --recursive",
     "prepublish": "npm run build",

--- a/src/rules/no-homogenous-tags.js
+++ b/src/rules/no-homogenous-tags.js
@@ -4,30 +4,55 @@ var rule = 'no-homogenous-tags';
 
 function noHomogenousTags(feature) {
   var errors = [];
-  if(feature.children !== undefined) {
-    var tagNames = _.flatten(_.map(feature.children, function(child) {
-      if ((child.type === 'Scenario' || child.type === 'ScenarioOutline') &&
-          child.tags !== undefined) {
-        return [_.map(child.tags, function(tag) {
-          return tag.name;
-        })];
-      } else {
-        return [];
-      }
-    }));
 
-    var homogenousTags = _.intersection.apply(_, tagNames);
-    if (homogenousTags.length !== 0) {
-      // You could argue that the line number should be the first instance of a
-      // bad tag, but I think this is really a problem with the whole feature.
-      errors = [{message: 'All Scenarios on this Feature have the same tag(s), ' +
-                            'they should be defined on the Feature instead: ' +
-                            _.join(homogenousTags, ', '),
-      rule   : rule,
-      line   : feature.location.line}];
+  if (feature.children) {
+    // Tags that exist in every scenario and scenario outline 
+    // should be applied on a feature level
+    var childrenTags = [];
+
+    feature.children.forEach(function(child) {
+      if (['Scenario', 'ScenarioOutline'].includes(child.type)) {
+
+        childrenTags.push(getTagNames(child));
+
+        if (child.examples) {
+          var exampleTags = [];
+          child.examples.forEach(function(example) {
+            exampleTags.push(getTagNames(example));
+          });
+
+          var homogenousExampleTags = _.intersection(...exampleTags);
+          if (homogenousExampleTags.length) {
+            errors.push({
+              message: 'All Examples of a Scenario Outline have the same tag(s), ' +
+                'they should be defined on the Scenario Outline instead: ' + 
+                homogenousExampleTags.join(', '),
+              rule: rule,
+              line: child.location.line
+            });
+          }
+        }
+      }
+    });
+
+    var homogenousTags = _.intersection(...childrenTags);
+    if (homogenousTags.length) {
+      errors.push({
+        message: 'All Scenarios on this Feature have the same tag(s), ' +
+          'they should be defined on the Feature instead: ' + 
+          homogenousTags.join(', '),
+        rule   : rule,
+        line   : feature.location.line
+      });
     }
   }
   return errors;
+}
+
+function getTagNames(node) {
+  return _.map(node.tags, function(tag) {
+    return tag.name;
+  });
 }
 
 module.exports = {

--- a/src/rules/no-partially-commented-tag-lines.js
+++ b/src/rules/no-partially-commented-tag-lines.js
@@ -21,7 +21,6 @@ function noPartiallyCommentedTagLines(feature) {
 
 function checkTags(node, errors) {
   if (node.tags) {
-    console.log(node.tags) //eslint-disable-line
     node.tags.forEach(function(tag) {
       if (tag.name.indexOf('#') > 0) {
         errors.push({message: 'Partially commented tag lines not allowed',

--- a/test-data-wip/.gherkin-lintrc
+++ b/test-data-wip/.gherkin-lintrc
@@ -2,7 +2,7 @@
   "no-files-without-scenarios" : "on",
   "no-unnamed-features": "on",
   "no-unnamed-scenarios": "on",
-  "no-dupe-scenario-names": "on",
+  "no-dupe-scenario-names": ["on", "in-feature"],
   "no-dupe-feature-names": "on",
   "no-partially-commented-tag-lines": "on",
   "indentation": "on",

--- a/test-data-wip/NoHomogenousTags.feature
+++ b/test-data-wip/NoHomogenousTags.feature
@@ -11,6 +11,12 @@ Scenario: This is a Scenario with some tags
 Scenario Outline: This is a Scenario with the same tags
   Then this is a then step <foo>
 
+  @homogenousExampleTag
+  Examples:
+  | foo |
+  | bar |
+
+  @homogenousExampleTag
   Examples:
   | foo |
   | bar |

--- a/test/rules/no-homogenous-tags/NoViolations.feature
+++ b/test/rules/no-homogenous-tags/NoViolations.feature
@@ -11,6 +11,13 @@ Scenario: This is a Scenario with multiple tags
 @tag3 @tag4
 Scenario Outline: This is a Scenario Outline with multiple tags
   Then this is a then step <foo>
+@tag5 @tag6
 Examples:
   | foo |
   | bar |
+
+@tag7 @tag8
+Examples:
+  | foo |
+  | bar |
+  

--- a/test/rules/no-homogenous-tags/Violations.feature
+++ b/test/rules/no-homogenous-tags/Violations.feature
@@ -10,6 +10,12 @@ Scenario: This is a Scenario with some tags
 @tag1 @tag2 @tag4
 Scenario Outline: This is a Scenario Outline with the same tags
   Then this is a then step <foo>
+@tag5 @tag6
+Examples:
+  | foo |
+  | bar |
+
+@tag5 @tag7
 Examples:
   | foo |
   | bar |

--- a/test/rules/no-homogenous-tags/no-homogenous-tags.js
+++ b/test/rules/no-homogenous-tags/no-homogenous-tags.js
@@ -1,7 +1,7 @@
 var ruleTestBase = require('../rule-test-base');
 var rule = require('../../../dist/rules/no-homogenous-tags.js');
 var runTest = ruleTestBase.createRuleTest(rule,
-  'All Scenarios on this Feature have the same tag(s), they should be defined on the Feature instead: <%= tags %>');
+  '<%= intro %> have the same tag(s), they should be defined on the <%= nodeType %> instead: <%= tags %>');
 
 describe('No Homogenous Tags Rule', function() {
   it('doesn\'t raise errors when there are no violations', function() {
@@ -9,9 +9,23 @@ describe('No Homogenous Tags Rule', function() {
   });
 
   it('detects errors for scenarios, and scenario outlines', function() {
-    runTest('no-homogenous-tags/Violations.feature', {}, [ {
-      line: 1,
-      messageElements: {tags: '@tag1, @tag2'}
-    }]);
+    runTest('no-homogenous-tags/Violations.feature', {}, [ 
+      {
+        line: 1,
+        messageElements: {
+          intro: 'All Scenarios on this Feature',
+          tags: '@tag1, @tag2',
+          nodeType: 'Feature'
+        }
+      },
+      {
+        line: 11,
+        messageElements: {
+          intro: 'All Examples of a Scenario Outline',
+          tags: '@tag5',
+          nodeType: 'Scenario Outline'
+        }
+      }
+    ]);
   });
 });


### PR DESCRIPTION
Additionally:
- Remove console.log statement from allowed tags rule, which was a
leftover from debugging
- Make demo only run against features in test-data-wip folder and check
for dupe scenario names just inside the same feature, so that its output
is shorter

fixes: #166 