### PR TITLE
security: ugrade lodash to v4.17.14

### DIFF
--- a/package.json
+++ b/package.json
@@ -70,7 +70,7 @@
     "commander": "2.18.0",
     "gherkin": "5.1.0",
     "glob": "7.1.3",
-    "lodash": "4.17.11"
+    "lodash": "4.17.14"
   },
   "devDependencies": {
     "@babel/cli": "7.4.4",


### PR DESCRIPTION
To avoid https://snyk.io/vuln/SNYK-JS-LODASH-450202