### PR TITLE
 stylish improvements 

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,7 +19,7 @@ git clone https://github.com/vsiakka/gherkin-lint.git
 npm run demo
 ```
 Or check this:
-![console](http://i.imgur.com/YaH4Anu.png)
+![console](https://i.imgur.com/Qfp1FQR.png)
 
 
 ## Available rules


### PR DESCRIPTION
- vertically align errors on a per file basis instead of doing it for all the files
- when the linter detects that it's running in tty, don't take into account error messages that are longer than the console width, when calculating alignment rules

These changes should make the error output more readable and pretty when the linter reports errors with really long messages (eg duplicate scenario names)
