### PR TITLE
Fix example typos for no-restricted-patterns

### DIFF
--- a/README.md
+++ b/README.md
@@ -93,22 +93,22 @@ The rule can be configured like this:
 ```
 {
   "no-restricted-patterns": ["on", {[
-    "Global": {
+    "Global": [
       "^globally restricted pattern"
-    },
-    "Feature": {
+    ],
+    "Feature": [
       "poor description",
       "validate",
       "verify"
-    },
-    "Background": {
+    ],
+    "Background": [
       "show last response",
       "a debugging step"
-    },
-    "Scenario": {
+    ],
+    "Scenario": [
       "show last response",
       "a debugging step"
-    }
+    ]
   ]}]
 }
 ```


### PR DESCRIPTION
Fix small typo for no-restricted-patterns rule configuration where `{}` was used. It should be `[]` since the values are arrays.