### PR TITLE
add support for comments in config file

### DIFF
--- a/README.md
+++ b/README.md
@@ -238,6 +238,8 @@ or
 ## Configuration File
 The default name for the configuration file is `.gherkin-lintrc` and it's expected to be in your working directory.
 
+The file contents must be valid JSON, though it does allow comments.
+
 If you are using a file with a different name or a file in a different folder, you will need to specify the `-c` or `--config` option and pass in the relative path to your configuration file. Eg: `gherkin-lint -c path/to/configuration/file.extention`
 
 You can find an example configuration file, that turns on all of the rules in the root of this repo (.gherkin-lintrc).

--- a/package-lock.json
+++ b/package-lock.json
@@ -2962,6 +2962,12 @@
             "ansi-regex": "^3.0.0"
           }
         },
+        "strip-json-comments": {
+          "version": "2.0.1",
+          "resolved": "https://registry.npmjs.org/strip-json-comments/-/strip-json-comments-2.0.1.tgz",
+          "integrity": "sha1-PFMZQukIwml8DsNEhYwobHygpgo=",
+          "dev": true
+        },
         "supports-color": {
           "version": "5.5.0",
           "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-5.5.0.tgz",
@@ -6333,10 +6339,9 @@
       "dev": true
     },
     "strip-json-comments": {
-      "version": "2.0.1",
-      "resolved": "https://registry.npmjs.org/strip-json-comments/-/strip-json-comments-2.0.1.tgz",
-      "integrity": "sha1-PFMZQukIwml8DsNEhYwobHygpgo=",
-      "dev": true
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/strip-json-comments/-/strip-json-comments-3.0.1.tgz",
+      "integrity": "sha512-VTyMAUfdm047mwKl+u79WIdrZxtFtn+nBxHeb844XBQ9uMNTuTHdx2hc5RiAJYqwTj3wc/xe5HLSdJSkJ+WfZw=="
     },
     "table": {
       "version": "5.2.3",

--- a/package.json
+++ b/package.json
@@ -79,7 +79,8 @@
     "core-js": "3.4.0",
     "gherkin": "5.1.0",
     "glob": "7.1.3",
-    "lodash": "4.17.14"
+    "lodash": "4.17.14",
+    "strip-json-comments": "^3.0.1"
   },
   "devDependencies": {
     "@babel/cli": "7.7.0",

--- a/src/config-parser.js
+++ b/src/config-parser.js
@@ -1,4 +1,5 @@
 var fs = require('fs');
+var stripJsonComments = require('strip-json-comments');
 var verifyConfig = require('./config-verifier.js');
 var logger = require('./logger.js');
 var defaultConfigFileName = '.gherkin-lintrc';
@@ -17,7 +18,7 @@ function getConfiguration(configPath, additionalRulesDirs) {
     }
     configPath = defaultConfigFileName;
   }
-  var config = JSON.parse(fs.readFileSync(configPath));
+  var config = JSON.parse(stripJsonComments(fs.readFileSync(configPath, {encoding: 'UTF-8'})));
   var errors = verifyConfig(config, additionalRulesDirs);
 
   if (errors.length > 0) {

--- a/test/config-parser/config-parser.js
+++ b/test/config-parser/config-parser.js
@@ -57,8 +57,16 @@ describe('Configuration parser', function() {
   describe('doesn\'t exit with exit code 1 when', function() {
     it('a good configuration file is used', function() {
       var configFilePath = 'test/config-parser/good_config.gherkinrc';
-      configParser.getConfiguration(configFilePath);
+      var parsedConfig = configParser.getConfiguration(configFilePath);
       expect(process.exit.neverCalledWith(1));
+      expect(parsedConfig).to.deep.eq({'no-files-without-scenarios': 'off'});
+    });
+
+    it('a good configuration file is used that includes comments', function() {
+      var configFilePath = 'test/config-parser/good_config_with_comments.gherkinrc';
+      var parsedConfig = configParser.getConfiguration(configFilePath);
+      expect(process.exit.neverCalledWith(1));
+      expect(parsedConfig).to.deep.eq({'no-files-without-scenarios': 'off'});
     });
 
     it('the default configuration file is found', function() {

--- a/test/config-parser/good_config_with_comments.gherkinrc
+++ b/test/config-parser/good_config_with_comments.gherkinrc
@@ -1,0 +1,7 @@
+/*
+block comment
+*/
+{
+  // inline comment
+  "no-files-without-scenarios" : "off"
+}


### PR DESCRIPTION
It's useful to be able to provide a comment-annotated lint config file as living policy documentation.

This adds support for JavaScript-style comments being present in the config file, and just strips them off right before parsing into an object, using https://github.com/sindresorhus/strip-json-comments (as used by ESLint for same purpose).