### PR TITLE
configure max-scenarios-per-file for whether each row of a Scenario Outline is counted

### DIFF
--- a/README.md
+++ b/README.md
@@ -151,14 +151,17 @@ This feature is able to handle all localizations of the gherkin steps.
 
 
 ### max-scenarios-per-file
-`max-scenarios-per-file` rule can be configured to set the number of max scenarios per file. The configuration looks like this:
+The `max-scenarios-per-file` supports some configuration options:
+
+- `maxScenarios` (number) the maximum scenarios per file after which the rule fails - defaults to `10`
+- `countOutlineExamples` (boolean) whether to count every example row for a Scenario Outline, as opposed to just 1 for the whole block - defaults to `true`
+
+The configuration looks like this (showing the defaults):
 ```
 {
-  "max-scenarios-per-file": {"on", {"maxScenarios": 10}}
+  "max-scenarios-per-file": {"on", {"maxScenarios": 10, "countOutlineExamples": true}}
 }
 ```
-The default value is 10.
-
 
 ### name-length
 

--- a/src/rules/max-scenarios-per-file.js
+++ b/src/rules/max-scenarios-per-file.js
@@ -2,7 +2,8 @@ var _ = require('lodash');
 var rule = 'max-scenarios-per-file';
 
 var defaultConfig = {
-  'maxScenarios': 10
+  'maxScenarios': 10,
+  'countOutlineExamples': true
 };
 
 function maxScenariosPerFile(feature, unused, config) {
@@ -19,7 +20,7 @@ function maxScenariosPerFile(feature, unused, config) {
         count = count - 1;
       }
 
-      if (scenario.examples) {
+      if (scenario.examples && mergedConfiguration.countOutlineExamples) {
         count = count - 1;
         scenario.examples.forEach(function (example) {
           if (example.tableBody) {

--- a/test/rules/max-scenarios-per-file/max-scenarios-per-file.js
+++ b/test/rules/max-scenarios-per-file/max-scenarios-per-file.js
@@ -13,4 +13,9 @@ describe('Max Scenarios per File rule', function () {
     runTest('max-scenarios-per-file/TooManyScenarios.feature', { maxScenarios: 10 }, [{ messageElements: { variable: 11 }, line: 0 }]);
     runTest('max-scenarios-per-file/TooManyExamples.feature', { maxScenarios: 10 }, [{ messageElements: { variable: 11 }, line: 0 }]);
   });
+
+  it('considers a scenario outline with many examples to be one scenario when "newThing" is on', function () {
+    runTest('max-scenarios-per-file/TooManyScenarios.feature', { maxScenarios: 10, countOutlineExamples: false }, [{ messageElements: { variable: 11 }, line: 0 }]);
+    runTest('max-scenarios-per-file/TooManyExamples.feature', { maxScenarios: 10, countOutlineExamples: false }, []);
+  });
 });


### PR DESCRIPTION
Adds another configuration option to the `max-scenarios-per-file` rule so that you can specify whether each row in a Scenario Outline table should be counted towards the number of scenarios (the current, and still default, behaviour) or whether the whole outline block should just count as 1.

