### PR TITLE
Fix documentation for `max-scenarios-per-file` and `no-restricted-patterns`

### DIFF
--- a/README.md
+++ b/README.md
@@ -159,7 +159,7 @@ The `max-scenarios-per-file` supports some configuration options:
 The configuration looks like this (showing the defaults):
 ```
 {
-  "max-scenarios-per-file": {"on", {"maxScenarios": 10, "countOutlineExamples": true}}
+  "max-scenarios-per-file": ["on", {"maxScenarios": 10, "countOutlineExamples": true}]
 }
 ```
 

--- a/README.md
+++ b/README.md
@@ -92,7 +92,7 @@ All patterns are treated as case insensitive.
 The rule can be configured like this:
 ```
 {
-  "no-restricted-patterns": ["on", {[
+  "no-restricted-patterns": ["on", {
     "Global": [
       "^globally restricted pattern"
     ],
@@ -109,7 +109,7 @@ The rule can be configured like this:
       "show last response",
       "a debugging step"
     ]
-  ]}]
+  }]
 }
 ```
 


### PR DESCRIPTION
Value for `max-scenarios-per-file` should be a list.