### PR TITLE
security: ugrade lodash to v4.17.20

### DIFF
--- a/package.json
+++ b/package.json
@@ -87,7 +87,7 @@
     "core-js": "3.6.4",
     "gherkin": "9.0.0",
     "glob": "7.1.6",
-    "lodash": "4.17.19",
+    "lodash": "4.17.20",
     "strip-json-comments": "3.0.1"
   },
   "devDependencies": {


### PR DESCRIPTION
To avoid https://snyk.io/test/npm/lodash/4.17.19