### PR TITLE
Add pattern support to tag rules

### DIFF
--- a/README.md
+++ b/README.md
@@ -76,11 +76,11 @@ will turn on the `no-unnamed-features` rule.
 
 ### allowed-tags
 
-`allowed-tags` must be configured with list of tags for it to have any effect:
+`allowed-tags` should be configured with the list of allowed tags and patterns:
 
 ```
 {
-  "allowed-tags": ["on", {"tags": ["@watch", "@wip", "@todo"]}]
+  "allowed-tags": ["on", {"tags": ["@watch", "@wip"], "patterns": ["^@todo$"]}]
 }
 ```
 
@@ -241,10 +241,10 @@ or
 
 
 ### no-restricted-tags
-`no-restricted-tags` should be configured with the list of restricted tags:
+`no-restricted-tags` should be configured with the list of restricted tags and patterns:
 ```
 {
-  "no-restricted-tags": ["on", {"tags": ["@watch", "@wip", "@todo"]}]
+  "no-restricted-tags": ["on", {"tags": ["@watch", "@wip"], "patterns": ["^@todo$"]}]
 }
 ```
 

--- a/src/rules/allowed-tags.js
+++ b/src/rules/allowed-tags.js
@@ -2,7 +2,8 @@ const _ = require('lodash');
 const rule = 'allowed-tags';
 
 const availableConfigs = {
-  'tags': []
+  'tags': [],
+  'patterns': []
 };
 
 function run(feature, unused, configuration) {
@@ -12,16 +13,17 @@ function run(feature, unused, configuration) {
 
   let errors = [];
   const allowedTags = configuration.tags;
+  const allowedPatterns = getAllowedPatterns(configuration);
 
-  checkTags(feature, allowedTags, errors);
+  checkTags(feature, allowedTags, allowedPatterns, errors);
 
   feature.children.forEach(child => {
     if (child.scenario) {
-      checkTags(child.scenario, allowedTags, errors);
+      checkTags(child.scenario, allowedTags, allowedPatterns, errors);
 
       if (child.scenario.examples) {
         child.scenario.examples.forEach(example => {
-          checkTags(example, allowedTags, errors);
+          checkTags(example, allowedTags, allowedPatterns, errors);
         });
       }
     }      
@@ -30,16 +32,21 @@ function run(feature, unused, configuration) {
   return errors;
 }
 
-function checkTags(node, allowedTags, errors) {
+function getAllowedPatterns(configuration) {
+  return (configuration.patterns || []).map((pattern) => new RegExp(pattern));
+}
+
+function checkTags(node, allowedTags, allowedPatterns, errors) {
   return (node.tags || [])
-    .filter(tag => !isAllowed(tag, allowedTags))
+    .filter(tag => !isAllowed(tag, allowedTags, allowedPatterns))
     .forEach(tag => {
       errors.push(createError(node, tag));
     });
 }
 
-function isAllowed(tag, allowedTags) {
-  return _.includes(allowedTags, tag.name);
+function isAllowed(tag, allowedTags, allowedPatterns) {
+  return _.includes(allowedTags, tag.name)
+    || allowedPatterns.some((pattern) => pattern.test(tag.name));
 }
 
 function createError(node, tag) {

--- a/test/rules/allowed-tags/NoViolations.feature
+++ b/test/rules/allowed-tags/NoViolations.feature
@@ -11,6 +11,7 @@ Scenario: This is a Scenario with multiple tags
 @scenariotag
 Scenario Outline: This is a Scenario Outline with multiple tags
   Then this is a then step <foo>
+@examplestag
 Examples:
   | foo |
   | bar |

--- a/test/rules/allowed-tags/allowed-tags.js
+++ b/test/rules/allowed-tags/allowed-tags.js
@@ -5,13 +5,15 @@ var runTest = ruleTestBase.createRuleTest(rule, 'Not allowed tag <%= tags %> on 
 describe('Allowed Tags Rule', function() {
   it('doesn\'t raise errors when there are no violations', function() {
     return runTest('allowed-tags/NoViolations.feature', {
-      'tags': ['@featuretag', '@scenariotag']
+      'tags': ['@featuretag', '@scenariotag'],
+      'patterns': ['^@examplestag$']
     }, []);
   });
 
   it('detects errors for features, scenarios, and scenario outlines', function() {
     return runTest('allowed-tags/Violations.feature', {
-      'tags': ['@featuretag', '@scenariotag', '@examplestag']
+      'tags': ['@featuretag', '@scenariotag'],
+      'patterns': ['^@examplestag$']
     }, [{
       messageElements: {tags: '@featuretag1', nodeType:'Feature'},
       line: 1

--- a/test/rules/no-restricted-tags/no-restricted-tags.js
+++ b/test/rules/no-restricted-tags/no-restricted-tags.js
@@ -5,13 +5,15 @@ var runTest = ruleTestBase.createRuleTest(rule, 'Forbidden tag <%= tag %> on <%=
 describe('No Restricted Tags Rule', function() {
   it('doesn\'t raise errors when there are no violations', function() {
     return runTest('no-restricted-tags/NoViolations.feature', {
-      'tags': ['@badTag']
+      'tags': ['@badTag'],
+      'patterns': ['^@anotherBadTag$']
     }, []);
   });
 
   it('detects errors for features, scenarios, and scenario outlines', function() {
     return runTest('no-restricted-tags/Violations.feature', {
-      'tags': ['@badTag', '@anotherBadTag']
+      'tags': ['@badTag'],
+      'patterns': ['^@anotherBadTag$']
     }, [{
       messageElements: {tag: '@badTag', nodeType:'Feature'},
       line: 1


### PR DESCRIPTION
Resolves #227

This adds a `"patterns"` configuration property to the `allowed-tags` and `no-restricted-tags` rules, which can be combined with the existing `"tags"` property to allow or forbid a list of patterns. This also changes the description of the `allowed-tags` in the README, since it was erroneous.