### PR TITLE
Add required-tags option to check untagged scenarios

### DIFF
--- a/README.md
+++ b/README.md
@@ -57,7 +57,7 @@ Or check this:
 | `no-unnamed-scenarios`                      | Disallows empty Scenario name                                                            |
 | `no-unused-variables`                       | Disallows unused variables in scenario outlines                                          |
 | `one-space-between-tags`                    | Tags on the same line must be separated by a single space                                |
-| `required-tags`                             | Require tags/patterns of tags on Scenarios                                               |
+| [`required-tags`](#required-tags)           | Require tags/patterns of tags on Scenarios                                               |
 | [`scenario-size`](#scenario-size)           | Allows restricting the maximum number of steps in a scenario, scenario outline and background |
 | `use-and`                                   | Disallows repeated step names requiring use of And instead                               |
 
@@ -245,6 +245,20 @@ or
 ```
 {
   "no-restricted-tags": ["on", {"tags": ["@watch", "@wip", "@todo"]}]
+}
+```
+
+
+### required-tags
+
+`required-tags` supports some configuration options:
+
+- `tags` (array) the array of tag patterns that must match at least one tag - defaults to `[]`
+- `ignore-untagged` (boolean) whether to ignore scenarios that have no tag - defaults to `true`
+
+```
+{
+  "required-tags": ["on", {"tags": ["^@issue:[1-9]\\d*$"], "ignore-untagged": false}]
 }
 ```
 

--- a/README.md
+++ b/README.md
@@ -254,11 +254,11 @@ or
 `required-tags` supports some configuration options:
 
 - `tags` (array) the array of tag patterns that must match at least one tag - defaults to `[]`
-- `ignore-untagged` (boolean) whether to ignore scenarios that have no tag - defaults to `true`
+- `ignoreUntagged` (boolean) whether to ignore scenarios that have no tag - defaults to `true`
 
 ```
 {
-  "required-tags": ["on", {"tags": ["^@issue:[1-9]\\d*$"], "ignore-untagged": false}]
+  "required-tags": ["on", {"tags": ["^@issue:[1-9]\\d*$"], "ignoreUntagged": false}]
 }
 ```
 

--- a/src/rules/required-tags.js
+++ b/src/rules/required-tags.js
@@ -3,8 +3,8 @@ const gherkinUtils = require('./utils/gherkin.js');
 
 const rule = 'required-tags';
 const availableConfigs = {
-  'tags': [],
-  'ignore-untagged': true
+  tags: [],
+  ignoreUntagged: true
 };
 
 
@@ -35,8 +35,8 @@ function run(feature, unused, config) {
       const line = child.scenario.location.line;
 
       // Check each Scenario for the required tags
-      const requiredTagErrors = mergedConfig['tags']
-        .map((requiredTag) => checkTagExists(requiredTag, mergedConfig['ignore-untagged'], child.scenario.tags || [], type, line))
+      const requiredTagErrors = mergedConfig.tags
+        .map((requiredTag) => checkTagExists(requiredTag, mergedConfig.ignoreUntagged, child.scenario.tags || [], type, line))
         .filter((item) =>
           typeof item === 'object' && item.message
         );

--- a/src/rules/required-tags.js
+++ b/src/rules/required-tags.js
@@ -1,25 +1,21 @@
+const _ = require('lodash');
 const gherkinUtils = require('./utils/gherkin.js');
 
 const rule = 'required-tags';
 const availableConfigs = {
-  tags: []
+  'tags': [],
+  'ignore-untagged': true
 };
 
 
-function checkTagExists(requiredTag, scenarioTags, scenarioType) {
-  const result = scenarioTags.length == 0
+function checkTagExists(requiredTag, ignoreUntagged, scenarioTags, scenarioType, scenarioLine) {
+  const result = (ignoreUntagged && scenarioTags.length == 0)
     || scenarioTags.some((tagObj) => RegExp(requiredTag).test(tagObj.name));
   if (!result) {
-    const lines = [];
-    scenarioTags.forEach((tag) => {
-      if (!lines.includes(tag.location.line)) {
-        lines.push(tag.location.line);
-      }
-    });
     return {
       message: `No tag found matching ${requiredTag} for ${scenarioType}`,
       rule,
-      line: lines.join(',')
+      line: scenarioLine
     };
   }
   return result;
@@ -30,14 +26,17 @@ function run(feature, unused, config) {
     return [];
   }
 
+  const mergedConfig = _.merge({}, availableConfigs, config);
+
   let errors = [];
   feature.children.forEach((child) => {
     if (child.scenario) {
       const type = gherkinUtils.getNodeType(child.scenario, feature.language);
+      const line = child.scenario.location.line;
 
       // Check each Scenario for the required tags
-      const requiredTagErrors = config.tags
-        .map(requiredTag => checkTagExists(requiredTag, child.scenario.tags || [], type))
+      const requiredTagErrors = mergedConfig['tags']
+        .map((requiredTag) => checkTagExists(requiredTag, mergedConfig['ignore-untagged'], child.scenario.tags || [], type, line))
         .filter((item) =>
           typeof item === 'object' && item.message
         );

--- a/test/rules/required-tags/Violations.feature
+++ b/test/rules/required-tags/Violations.feature
@@ -16,3 +16,9 @@ Scenario Outline: This is a Scenario Outline with some of the required tags miss
 Examples:
   | foo |
   | bar |
+
+Scenario: This is a Scenario that has no tag
+  Then I should see an error
+
+Scenario Outline: This is a Scenario Outline that has no tag
+  Then I should see an error

--- a/test/rules/required-tags/required-tags.js
+++ b/test/rules/required-tags/required-tags.js
@@ -13,16 +13,28 @@ describe('Required Tags Rule', function() {
       'tags': ['@requiredscenariotag', '@requiredScenarioTag', '@required-scenario-tag-\\d+']
     }, [{
       messageElements: {tags: '@requiredScenarioTag', nodeType: 'Scenario'},
-      line: '7'
+      line: 8
     }, {
       messageElements: {tags: '@requiredScenarioTag', nodeType: 'Scenario Outline'},
-      line: '11,12'
+      line: 13
     }, {
       messageElements: {tags: '@required-scenario-tag-\\d+', nodeType: 'Scenario'},
-      line: '7'
+      line: 8
     }, {
       messageElements: {tags: '@required-scenario-tag-\\d+', nodeType: 'Scenario Outline'},
-      line: '11,12'
+      line: 13
+    }]);
+  });
+  it('detects errors for scenarios and scenario outlines that have no tag', () => {
+    return runTest('required-tags/Violations.feature', {
+      'tags': ['@requiredscenariotag'],
+      'ignore-untagged': false
+    }, [{
+      messageElements: {tags: '@requiredscenariotag', nodeType: 'Scenario'},
+      line: 20
+    }, {
+      messageElements: {tags: '@requiredscenariotag', nodeType: 'Scenario Outline'},
+      line: 23
     }]);
   });
 });

--- a/test/rules/required-tags/required-tags.js
+++ b/test/rules/required-tags/required-tags.js
@@ -28,7 +28,7 @@ describe('Required Tags Rule', function() {
   it('detects errors for scenarios and scenario outlines that have no tag', () => {
     return runTest('required-tags/Violations.feature', {
       'tags': ['@requiredscenariotag'],
-      'ignore-untagged': false
+      'ignoreUntagged': false
     }, [{
       messageElements: {tags: '@requiredscenariotag', nodeType: 'Scenario'},
       line: 20


### PR DESCRIPTION
Resolves #238 

This adds an `"ignoreUntagged"` configuration property to the `required-tags` rule. The default value is `true` to retain the current behaviour. When the option is set to `false`, scenarios that do not have any tag are no longer ignored by the rule (and an error will be reported if the list of required tag patterns is not empty).