### PR TITLE
Add xunit formatter

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -5634,6 +5634,11 @@
       "integrity": "sha512-YZo3K82SD7Riyi0E1EQPojLz7kpepnSQI9IyPbHHg1XXXevb5dJI7tpyN2ADxGcQbHG7vcyRHk0cbwqcQriUtg==",
       "dev": true
     },
+    "sax": {
+      "version": "1.2.4",
+      "resolved": "https://registry.npmjs.org/sax/-/sax-1.2.4.tgz",
+      "integrity": "sha512-NqVDv9TpANUjFm0N8uM5GxL36UgKi9/atZw+x7YFnQ8ckwFGKrl4xX4yWtrey3UJm5nP1kUbnYgLopqWNSRhWw=="
+    },
     "semver": {
       "version": "5.7.1",
       "resolved": "https://registry.npmjs.org/semver/-/semver-5.7.1.tgz",
@@ -6579,6 +6584,14 @@
         "is-typedarray": "^1.0.0",
         "signal-exit": "^3.0.2",
         "typedarray-to-buffer": "^3.1.5"
+      }
+    },
+    "xml-js": {
+      "version": "1.6.11",
+      "resolved": "https://registry.npmjs.org/xml-js/-/xml-js-1.6.11.tgz",
+      "integrity": "sha512-7rVi2KMfwfWFl+GpPg6m80IVMWXLRjO+PxTq7V2CDhoGak0wzYzFgUY2m4XJ47OGdXd8eLE8EmwfAmdjw7lC1g==",
+      "requires": {
+        "sax": "^1.2.4"
       }
     },
     "y18n": {

--- a/package.json
+++ b/package.json
@@ -88,7 +88,8 @@
     "gherkin": "9.0.0",
     "glob": "7.1.6",
     "lodash": "4.17.20",
-    "strip-json-comments": "3.0.1"
+    "strip-json-comments": "3.0.1",
+    "xml-js": "^1.6.11"
   },
   "devDependencies": {
     "@babel/cli": "7.8.4",

--- a/src/formatters/xunit.js
+++ b/src/formatters/xunit.js
@@ -1,0 +1,36 @@
+function printResults(results) {
+  const testCases = results.map(result => ({
+    _attributes: {
+      name : result.filePath
+    },
+    error: result.errors.map(error => ({
+      _attributes: {
+        message: error.message,
+        type: 'gherkin-lint-error'
+      },
+      _cdata: `${result.filePath}:${error.line} (${error.rule}) ${error.message}`        
+    }))    
+  }));
+  const testSuiteReport = {
+    _declaration:{
+      _attributes: {
+        version: '1.0',
+        encoding: 'utf-8'
+      }
+    },
+    testsuite : {
+      _attributes: {
+        name: 'gherkin-lint',
+      },
+      testcase : testCases
+    }
+  };
+  let convert = require('xml-js');
+  const xunitXml = convert.js2xml(testSuiteReport, {compact: true, spaces: 4});
+  /*eslint no-console: "off"*/
+  console.error(xunitXml);
+}
+
+module.exports = {
+  printResults: printResults
+};

--- a/src/main.js
+++ b/src/main.js
@@ -17,7 +17,7 @@ function collect(val, memo) {
 
 program
   .usage('[options] <feature-files>')
-  .option('-f, --format [format]', 'output format. Possible values: json, stylish. Defaults to stylish')
+  .option('-f, --format [format]', 'output format. Possible values: json, stylish, xunit. Defaults to stylish')
   .option('-i, --ignore <...>', 'comma seperated list of files/glob patterns that the linter should ignore, overrides ' + featureFinder.defaultIgnoreFileName + ' file', list)
   .option('-c, --config [config]', 'configuration file, defaults to ' + configParser.defaultConfigFileName)
   .option('-r, --rulesdir <...>', 'additional rule directories', collect, [])
@@ -46,10 +46,12 @@ function printResults(results, format) {
   let formatter;
   if (format === 'json') {
     formatter = require('./formatters/json.js');
-  } else if (!format || format == 'stylish') {
+  } else if (format === 'xunit') {
+    formatter = require('./formatters/xunit.js');
+  } else if (!format || format === 'stylish') {
     formatter = require('./formatters/stylish.js');
   } else {
-    logger.boldError('Unsupported format. The supported formats are json and stylish.');
+    logger.boldError('Unsupported format. The supported formats are json, xunit and stylish.');
     process.exit(1);
   }
   formatter.printResults(results);


### PR DESCRIPTION
Add support for j/xunit formatting, see #240 

Example output for failing tests: 

Json input: 

```json
{
  "filePath":"C:\\[redacted]\\UseAnd.feature",
  "errors":[ 
    {"message":"Backgrounds are not allowed when there is just one scenario.","rule":"no-background-only-scenario","line":3},
    {"message":"Step \"Given third statement that does not use and\" should use And instead of Given ","rule":"use-and","line":6}, 
   {"message":"Step \"When second step without and\" should use And instead of When ","rule":"use-and","line":11}, 
   {"message":"Step \"Then second assertion without and\" should use And instead of Then ","rule":"use-and","line":14}
  ]
}
```

```xml
<?xml version="1.0" encoding="utf-8"?>
<testsuite name="gherkin-lint">
    <testcase name="C:\[redacted]\gherkin-lint\test-data-wip\UseAnd.feature">
        <error message="Backgrounds are not allowed when there is just one scenario." type="gherkin-lint-error"><![CDATA[C:\[redacted]\gherkin-lint\test-data-wip\UseAnd.feature:3 (no-background-only-scenario) Backgrounds are not allowed when there is just one scenario.]]></error>
        <error message="Step &quot;Given third statement that does not use and&quot; should use And instead of Given " type="gherkin-lint-error"><![CDATA[C:\[redacted]\gherkin-lint\test-data-wip\UseAnd.feature:6 (use-and) Step "Given third statement that does not use and" should use And instead of Given ]]></error>
        <error message="Step &quot;When second step without and&quot; should use And instead of When " type="gherkin-lint-error"><![CDATA[C:\[redacted]\gherkin-lint\test-data-wip\UseAnd.feature:11 (use-and) Step "When second step without and" should use And instead of When ]]></error>
        <error message="Step &quot;Then second assertion without and&quot; should use And instead of Then " type="gherkin-lint-error"><![CDATA[C:\[redacted]\gherkin-lint\test-data-wip\UseAnd.feature:14 (use-and) Step "Then second assertion without and" should use And instead of Then ]]></error>
    </testcase>
</testsuite>
```