### PR TITLE
Ignore `no-unused-variables` when there's no Examples table

### DIFF
--- a/src/rules/no-unused-variables.js
+++ b/src/rules/no-unused-variables.js
@@ -14,13 +14,20 @@ function run(feature) {
       return;
     }
 
+    const examples = child.scenario.examples;
+
+    if (!examples.length) {
+      // If there is no examples table, the rule doesn't apply
+      return;
+    }
+
     // Maps of variableName -> lineNo
     const examplesVariables = {};
     const scenarioVariables = {};
     let match;
 
     // Collect all the entries of the examples table
-    child.scenario.examples.forEach(example => {
+    examples.forEach(example => {
       if (example.tableHeader && example.tableHeader.cells) {
         example.tableHeader.cells.forEach(cell => {
           if (cell.value) {

--- a/test/rules/no-unused-variables/NoViolations.feature
+++ b/test/rules/no-unused-variables/NoViolations.feature
@@ -5,6 +5,10 @@ Background:
   Then I shouldn't get an unused variable error
 
 Scenario:
+  Given I have a scenario step with a word that looks like a <variable> even though it's not, because there's no examples table
+  Then I shouldn't get an unused variable error
+
+Scenario:
   Given I have a scenario step with a word that looks like a <a> 
   Then I shouldn get an unused variable error cause 
   


### PR DESCRIPTION
Fixes #234.