### PR TITLE
Allow additionalRulesDirs to be specified in config

### DIFF
--- a/README.md
+++ b/README.md
@@ -274,12 +274,12 @@ There are 2 ways you can specify files that the linter should ignore:
 
 
 ## Custom rules
-You can specify one more more custom rules directories by using the `-r` or `--rulesdir` command line option. Rules in the given directories will be available additionally to the default rules.
+You can specify one more more custom rules directories in the configuration file, or by using the `-r` or `--rulesdir` command line option. Rules in the given directories will be available additionally to the default rules.
 
 Example:
 ```
 gherkin-lint --rulesdir "/path/to/my/rulesdir" --rulesdir "from/cwd/rulesdir"
 ```
 
-Paths can either be absolute or relative to the current working directory.
+Paths specified in the gherkin-lintrc should be speified relative to the gherkin-lintrc. Paths specified as a command line option can either be absolute or relative to the current working directory.
 Have a look at the `src/rules/` directory for examples; The `no-empty-file` rule is a good example to start with.

--- a/package.json
+++ b/package.json
@@ -71,6 +71,10 @@
     {
       "name": "Alexander Bayandin",
       "url": "https://github.com/bayandin"
+    },
+    {
+      "name": "Andrew Nicols",
+      "url": "https://github.com/andrewnicols"
     }
   ],
   "main": "dist/main.js",

--- a/src/config-verifier.js
+++ b/src/config-verifier.js
@@ -3,6 +3,14 @@ const rules = require('./rules.js');
 function verifyConfigurationFile(config, additionalRulesDirs) {
   let errors = [];
   for (let rule in config) {
+    if (rule === 'additionalRulesDirs') {
+      if (!Array.isArray(config[rule])) {
+        // The additionalRulesDirs must be an Array.
+        const genericErrorMsg = 'Invalid rule configuration for "' + rule + '" - ';
+        errors.push(genericErrorMsg + 'The config should be an Array.');
+      }
+      continue;
+    }
     if (!rules.doesRuleExist(rule, additionalRulesDirs)) {
       errors.push('Rule "' + rule + '" does not exist');
     } else {

--- a/src/linter.js
+++ b/src/linter.js
@@ -59,6 +59,14 @@ function readAndParseFile(filePath) {
 function lint(files, configuration, additionalRulesDirs) {
   let results = [];
 
+  // Ensure configuration exists.
+  configuration = configuration || {};
+
+  if (!additionalRulesDirs && configuration.additionalRulesDirs) {
+    // Fallback to config.additionalRulesDirs if additionalRulesDirs was empty.
+    additionalRulesDirs = configuration.additionalRulesDirs;
+  }
+
   return Promise.all(files.map((f) => {
     let perFileErrors = [];
 

--- a/src/main.js
+++ b/src/main.js
@@ -26,7 +26,7 @@ program
 const additionalRulesDirs = program.rulesdir;
 const files = featureFinder.getFeatureFiles(program.args, program.ignore);
 const config = configParser.getConfiguration(program.config, additionalRulesDirs);
-linter.lint(files, config, additionalRulesDirs)
+linter.lint(files, config)
   .then((results) => {
     printResults(results, program.format);
     process.exit(getExitCode(results));

--- a/test/config-parser/config-parser.js
+++ b/test/config-parser/config-parser.js
@@ -76,4 +76,49 @@ describe('Configuration parser', function() {
       expect(process.exit.neverCalledWith(1));
     });
   });
+
+  describe('handles additionalRulesDirs configuration correctly by', function() {
+    it('resolving paths relative to the configuration file', function() {
+      var path = require('path');
+
+      var configFileDir = 'test/config-parser/';
+      var configFilePath = path.resolve(configFileDir, 'good_config_with_rulesdirs.gherkinrc');
+      var parsedConfig = configParser.getConfiguration(configFilePath);
+
+      var expectedPaths = [
+        path.resolve(configFileDir, 'rulesdir'),
+        path.resolve(configFileDir, 'rules'),
+        path.resolve(configFileDir, 'gherkin/rules'),
+      ];
+
+      expect(process.exit.neverCalledWith(1));
+      expect(parsedConfig).to.deep.eq({'additionalRulesDirs': expectedPaths});
+    });
+
+    it('using specified additionalRulesDirs instead of configuration', function() {
+      var path = require('path');
+
+      var configFileDir = 'test/config-parser/';
+      var configFilePath = path.resolve(configFileDir, 'good_config_with_rulesdirs.gherkinrc');
+      var parsedConfig = configParser.getConfiguration(configFilePath, []);
+
+      var expectedPaths = [];
+
+      expect(process.exit.neverCalledWith(1));
+      expect(parsedConfig).to.deep.eq({'additionalRulesDirs': expectedPaths});
+    });
+
+    it('not modifying supplied additionalRulesDirs', function() {
+      var path = require('path');
+
+      var configFileDir = 'test/config-parser/';
+      var configFilePath = path.resolve(configFileDir, 'good_config_with_rulesdirs.gherkinrc');
+      var parsedConfig = configParser.getConfiguration(configFilePath, ['example/rules/dir']);
+
+      var expectedPaths = ['example/rules/dir'];
+
+      expect(process.exit.neverCalledWith(1));
+      expect(parsedConfig).to.deep.eq({'additionalRulesDirs': expectedPaths});
+    });
+  });
 });

--- a/test/config-parser/good_config_with_rulesdirs.gherkinrc
+++ b/test/config-parser/good_config_with_rulesdirs.gherkinrc
@@ -1,0 +1,3 @@
+{
+  "additionalRulesDirs" : ["rulesdir", "./rules", "gherkin/rules"]
+}

--- a/test/config-verifier.js
+++ b/test/config-verifier.js
@@ -26,6 +26,10 @@ describe('Config Verifier', function() {
         'indentation': ['on', { 'Feature': 1, 'Background': 1, 'Scenario': 1, 'Step': 1, 'given': 1, 'and': 1}]
       }), []);
     });
+
+    it('an additional rule directory is specified', function() {
+      assert.deepEqual(verifyConfig({'additionalRulesDirs': ['.rules']}), []);
+    });
   });
 
   describe('Verification fails when', function() {
@@ -61,6 +65,12 @@ describe('Config Verifier', function() {
 
       assert.deepEqual(verifyConfig({'new-line-at-eof': ['on', 'yes', 'p3']}), [
         'Invalid rule configuration for "new-line-at-eof" -  The config should only have 2 parts.'
+      ]);
+    });
+
+    it('an additional rule directory is not an array', function() {
+      assert.deepEqual(verifyConfig({'additionalRulesDirs': 'a'}), [
+        'Invalid rule configuration for "additionalRulesDirs" - The config should be an Array.'
       ]);
     });
   });

--- a/test/rulesdir/.gherkin-lintrc-invalid-rulesdir
+++ b/test/rulesdir/.gherkin-lintrc-invalid-rulesdir
@@ -1,0 +1,7 @@
+{
+  "additionalRulesDirs": ["some_invalid_path"],
+  "indentation": "on",
+  "custom" : "on",
+  "another-custom" : "on",
+  "another-custom-list" : ["on", {"element": ["first_element"]}]
+}

--- a/test/rulesdir/.gherkin-lintrc-rulesdir
+++ b/test/rulesdir/.gherkin-lintrc-rulesdir
@@ -1,0 +1,7 @@
+{
+  "additionalRulesDirs": ["rules", "./other_rules"],
+  "indentation": "on",
+  "custom" : "on",
+  "another-custom" : "on",
+  "another-custom-list" : ["on", {"element": ["first_element"]}]
+}

--- a/test/rulesdir/rulesdir.js
+++ b/test/rulesdir/rulesdir.js
@@ -3,6 +3,35 @@ var expect = require('chai').expect;
 var linter = require('../../dist/linter');
 var configParser = require('../../dist/config-parser');
 
+var featureFile = path.join(__dirname, 'simple.features');
+var expectedResult = [
+  {
+    errors: [
+      { // This one is to make sure we don't accidentally regress and always load the default rules
+        line: 1,
+        message: 'Wrong indentation for "Feature", expected indentation level of 0, but got 4',
+        rule: 'indentation'
+      },
+      {
+        line: 109,
+        message: 'Another custom-list error',
+        rule: 'another-custom-list'
+      },
+      {
+        line: 123,
+        message: 'Custom error',
+        rule: 'custom'
+      },
+      {
+        line: 456,
+        message: 'Another custom error',
+        rule: 'another-custom'
+      }
+    ],
+    filePath: featureFile
+  }
+];
+
 describe('rulesdir CLI option', function() {
   it('loads additional rules from specified directories', function() {
     var additionalRulesDirs = [
@@ -10,36 +39,33 @@ describe('rulesdir CLI option', function() {
       path.join('test', 'rulesdir', 'other_rules') // relative path from root
     ];
     var config = configParser.getConfiguration(path.join(__dirname, '.gherkin-lintrc'), additionalRulesDirs);
-    var featureFile = path.join(__dirname, 'simple.features');
-    return linter.lint([ featureFile ], config, additionalRulesDirs)
+    return linter.lint([ featureFile ], config)
       .then((results) => {
-        expect(results).to.deep.equal([
-          {
-            errors: [
-              { // This one is to make sure we don't accidentally regress and always load the default rules
-                line: 1,
-                message: 'Wrong indentation for "Feature", expected indentation level of 0, but got 4',
-                rule: 'indentation'
-              },
-              {
-                line: 109,
-                message: 'Another custom-list error',
-                rule: 'another-custom-list'
-              },
-              {
-                line: 123,
-                message: 'Custom error',
-                rule: 'custom'
-              },
-              {
-                line: 456,
-                message: 'Another custom error',
-                rule: 'another-custom'
-              }
-            ],
-            filePath: featureFile
-          }
-        ]);
+        expect(results).to.deep.equal(expectedResult);
       });
-  });    
+  });
+});
+
+describe('rulesdir .gherkin-lintrc config option', function() {
+  it('loads additional rules from specified directories', function() {
+    var config = configParser.getConfiguration(path.join(__dirname, '.gherkin-lintrc-rulesdir'));
+    return linter.lint([ featureFile ], config)
+      .then((results) => {
+        expect(results).to.deep.equal(expectedResult);
+      });
+  });
+});
+
+describe('rulesdir CLI option overrides .gherkin-lintrc config option', function() {
+  it('loads additional rules from specified directories', function() {
+    var additionalRulesDirs = [
+      path.join(__dirname, 'rules'), // absolute path
+      path.join('test', 'rulesdir', 'other_rules') // relative path from root
+    ];
+    var config = configParser.getConfiguration(path.join(__dirname, '.gherkin-lintrc-invalid-rulesdir'), additionalRulesDirs);
+    return linter.lint([ featureFile ], config)
+      .then((results) => {
+        expect(results).to.deep.equal(expectedResult);
+      });
+  });
 });


### PR DESCRIPTION
Allow a list of additionalRulesDirs to be specified in the
gherkin-lintrc configuration.

If a list of paths is provided as an argument then this takes precedence
over the value in configuration.

Any additionalRulesDirs specified in configuration is calculated
relative to the gherkin-lintrc.