### PR TITLE
Restructure gherkinrc file to place rules in rules

### DIFF
--- a/README.md
+++ b/README.md
@@ -70,7 +70,9 @@ The not-configurable rules are turned on by default and cannot be turned off. Co
 The configurable rules are off by default. To turn them on, you will need to create a json file, where you specify the name of each rule and its desired state (which can be "on" or "off"). Eg:
 ```
 {
-  "no-unnamed-features": "on"
+  "rules": {
+    "no-unnamed-features": "on"
+  }
 }
 ```
 will turn on the `no-unnamed-features` rule.
@@ -81,7 +83,9 @@ will turn on the `no-unnamed-features` rule.
 
 ```
 {
-  "allowed-tags": ["on", {"tags": ["@watch", "@wip"], "patterns": ["^@todo$"]}]
+  "rules": {
+    "allowed-tags": ["on", {"tags": ["@watch", "@wip"], "patterns": ["^@todo$"]}]
+  }
 }
 ```
 
@@ -93,7 +97,9 @@ Any tag not included in this list won't be allowed.
 
 ```json
 {
-  "file-name": ["on", {"style": "PascalCase"}]
+  "rules": {
+    "file-name": ["on", {"style": "PascalCase"}]
+  }
 }
 ```
 
@@ -112,24 +118,26 @@ All patterns are treated as case insensitive.
 The rule can be configured like this:
 ```
 {
-  "no-restricted-patterns": ["on", {
-    "Global": [
-      "^globally restricted pattern"
-    ],
-    "Feature": [
-      "poor description",
-      "validate",
-      "verify"
-    ],
-    "Background": [
-      "show last response",
-      "a debugging step"
-    ],
-    "Scenario": [
-      "show last response",
-      "a debugging step"
-    ]
-  }]
+  "rules": {
+    "no-restricted-patterns": ["on", {
+      "Global": [
+        "^globally restricted pattern"
+      ],
+      "Feature": [
+        "poor description",
+        "validate",
+        "verify"
+      ],
+      "Background": [
+        "show last response",
+        "a debugging step"
+      ],
+      "Scenario": [
+        "show last response",
+        "a debugging step"
+      ]
+    }]
+  }
 }
 ```
 
@@ -146,23 +154,25 @@ Notes:
 You can override the defaults for `indentation` like this:
 ```
 {
-  "indentation" : [
-    "on", {
-      "Feature": 0,
-      "Background": 0,
-      "Scenario": 0,
-      "Step": 2,
-      "Examples": 0,
-      "example": 2,
-      "given": 2,
-      "when": 2,
-      "then": 2,
-      "and": 2,
-      "but": 2,
-      "feature tag": 0,
-      "scenario tag": 0
-    }
-  ]
+  "rules": {
+    "indentation" : [
+      "on", {
+        "Feature": 0,
+        "Background": 0,
+        "Scenario": 0,
+        "Step": 2,
+        "Examples": 0,
+        "example": 2,
+        "given": 2,
+        "when": 2,
+        "then": 2,
+        "and": 2,
+        "but": 2,
+        "feature tag": 0,
+        "scenario tag": 0
+      }
+    ]
+  }
 }
 ```
 There is no need to override all the defaults, as is done above, instead they can be overriden only where required.  `Step` will be used as a fallback if the keyword of the step, eg. 'given', is not specified.  If `feature tag` is not set then `Feature` is used as a fallback, and if `scenario tag` is not set then `Scenario` is used as a fallback.
@@ -179,7 +189,9 @@ The `max-scenarios-per-file` supports some configuration options:
 The configuration looks like this (showing the defaults):
 ```
 {
-  "max-scenarios-per-file": ["on", {"maxScenarios": 10, "countOutlineExamples": true}]
+  "rules": {
+    "max-scenarios-per-file": ["on", {"maxScenarios": 10, "countOutlineExamples": true}]
+  }
 }
 ```
 
@@ -191,7 +203,9 @@ The default is 70 characters for each of these:
 
 ```
 {
-  "name-length" : ["on", { "Feature": 70, "Scenario": 70, "Step": 70 }]
+  "rules": {
+    "name-length" : ["on", { "Feature": 70, "Scenario": 70, "Step": 70 }]
+  }
 }
 ```
 
@@ -202,13 +216,17 @@ The default is 70 characters for each of these:
 - To enforce new lines at EOF:
 ```
 {
-  "new-line-at-eof": ["on", "yes"]
+  "rules": {
+    "new-line-at-eof": ["on", "yes"]
+  }
 }
 ```
 - To disallow new lines at EOF:
 ```
 {
-  "new-line-at-eof": ["on", "no"]
+  "rules": {
+    "new-line-at-eof": ["on", "no"]
+  }
 }
 ```
 
@@ -220,7 +238,9 @@ To enable searching for duplicates in each individual feature (same scenario nam
 
 ```
 {
-  "no-dupe-scenario-names": ["on", "in-feature"]
+  "rules": {
+    "no-dupe-scenario-names": ["on", "in-feature"]
+  }
 }
 ```
 
@@ -228,7 +248,9 @@ The default case is testing against all the features (same scenario name in diff
 
 ```
 {
-  "no-dupe-scenario-names": "on"
+  "rules": {
+    "no-dupe-scenario-names": "on"
+  }
 }
 ```
 
@@ -236,7 +258,9 @@ or
 
 ```
 {
-  "no-dupe-scenario-names": ["on", "anywhere"]
+  "rules": {
+    "no-dupe-scenario-names": ["on", "anywhere"]
+  }
 }
 ```
 
@@ -245,7 +269,9 @@ or
 `no-restricted-tags` should be configured with the list of restricted tags and patterns:
 ```
 {
-  "no-restricted-tags": ["on", {"tags": ["@watch", "@wip"], "patterns": ["^@todo$"]}]
+  "rules": {
+    "no-restricted-tags": ["on", {"tags": ["@watch", "@wip"], "patterns": ["^@todo$"]}]
+  }
 }
 ```
 
@@ -255,7 +281,9 @@ or
 `scenario-size` lets you specify a maximum step length for scenarios and backgrounds. The `Scenario` configuration applies to both scenarios and scenario outlines:
 ```
 {
-  "scenario-size": ["on", { "steps-length": { "Background": 15, "Scenario": 15 }}]
+  "rules": {
+    "scenario-size": ["on", { "steps-length": { "Background": 15, "Scenario": 15 }}]
+  }
 }
 ```
 

--- a/package.json
+++ b/package.json
@@ -71,6 +71,10 @@
     {
       "name": "Alexander Bayandin",
       "url": "https://github.com/bayandin"
+    },
+    {
+      "name": "Andrew Nicols",
+      "url": "https://github.com/andrewnicols"
     }
   ],
   "main": "dist/main.js",

--- a/src/config-verifier.js
+++ b/src/config-verifier.js
@@ -2,11 +2,14 @@ const rules = require('./rules.js');
 
 function verifyConfigurationFile(config, additionalRulesDirs) {
   let errors = [];
-  for (let rule in config) {
-    if (!rules.doesRuleExist(rule, additionalRulesDirs)) {
-      errors.push('Rule "' + rule + '" does not exist');
-    } else {
-      verifyRuleConfiguration(rule, config[rule], additionalRulesDirs, errors);
+  if (config.rules) {
+    let ruleConfig = config.rules;
+    for (let rule in ruleConfig) {
+      if (!rules.doesRuleExist(rule, additionalRulesDirs)) {
+        errors.push('Rule "' + rule + '" does not exist');
+      } else {
+        verifyRuleConfiguration(rule, ruleConfig[rule], additionalRulesDirs, errors);
+      }
     }
   }
   return errors;

--- a/src/rules/use-and.js
+++ b/src/rules/use-and.js
@@ -12,8 +12,7 @@ function run(feature) {
   feature.children.forEach(child => {
     const node = child.rule || child.background || child.scenario;
     let previousKeyword = undefined;
-    if (node.steps)
-    {
+    if (node.steps) {
       node.steps.forEach(step => {
         const keyword = gherkinUtils.getLanguageInsitiveKeyword(step, feature.language);
 

--- a/test/config-parser/bad_config.gherkinrc
+++ b/test/config-parser/bad_config.gherkinrc
@@ -1,3 +1,5 @@
 {
-  "fake-rule" : "on"
+  "rules": {
+    "fake-rule" : "on"
+  }
 }

--- a/test/config-parser/config-parser.js
+++ b/test/config-parser/config-parser.js
@@ -59,14 +59,14 @@ describe('Configuration parser', function() {
       var configFilePath = 'test/config-parser/good_config.gherkinrc';
       var parsedConfig = configParser.getConfiguration(configFilePath);
       expect(process.exit.neverCalledWith(1));
-      expect(parsedConfig).to.deep.eq({'no-files-without-scenarios': 'off'});
+      expect(parsedConfig).to.deep.eq({'rules': {'no-files-without-scenarios': 'off'}});
     });
 
     it('a good configuration file is used that includes comments', function() {
       var configFilePath = 'test/config-parser/good_config_with_comments.gherkinrc';
       var parsedConfig = configParser.getConfiguration(configFilePath);
       expect(process.exit.neverCalledWith(1));
-      expect(parsedConfig).to.deep.eq({'no-files-without-scenarios': 'off'});
+      expect(parsedConfig).to.deep.eq({'rules': {'no-files-without-scenarios': 'off'}});
     });
 
     it('the default configuration file is found', function() {

--- a/test/config-parser/good_config.gherkinrc
+++ b/test/config-parser/good_config.gherkinrc
@@ -1,3 +1,5 @@
 {
-  "no-files-without-scenarios" : "off"
+  "rules": {
+    "no-files-without-scenarios" : "off"
+  }
 }

--- a/test/config-parser/good_config_with_comments.gherkinrc
+++ b/test/config-parser/good_config_with_comments.gherkinrc
@@ -3,5 +3,7 @@ block comment
 */
 {
   // inline comment
-  "no-files-without-scenarios" : "off"
+  "rules": {
+    "no-files-without-scenarios" : "off"
+  }
 }

--- a/test/config-parser/stub_default.gherkinrc
+++ b/test/config-parser/stub_default.gherkinrc
@@ -1,3 +1,5 @@
 {
-  "no-files-without-scenarios" : "off"
+  "rules": {
+    "no-files-without-scenarios" : "off"
+  }
 }

--- a/test/config-verifier.js
+++ b/test/config-verifier.js
@@ -30,13 +30,15 @@ describe('Config Verifier', function() {
 
   describe('Verification fails when', function() {
     it('a non existing rule', function() {
-      assert.deepEqual(verifyConfig({'fake-rule': 'on'}), ['Rule "fake-rule" does not exist']);
+      assert.deepEqual(verifyConfig({'rules': {'fake-rule': 'on'}}), ['Rule "fake-rule" does not exist']);
     });
 
     it('a non existing rule sub-config', function() {
       assert.deepEqual(verifyConfig({
-        'indentation': ['on', { 'featur': 0}],
-        'new-line-at-eof': ['on', 'y']
+        'rules': {
+          'indentation': ['on', { 'featur': 0}],
+          'new-line-at-eof': ['on', 'y']
+        }
       }), [
         'Invalid rule configuration for "indentation" -  The rule does not have the specified configuration option "featur"',
         'Invalid rule configuration for "new-line-at-eof" -  The rule does not have the specified configuration option "y"'
@@ -45,9 +47,11 @@ describe('Config Verifier', function() {
 
     it('rule config that\'s not properly configured to "on/off"', function() {
       assert.deepEqual(verifyConfig({
-        'no-files-without-scenarios': 'o',
-        'new-line-at-eof': ['o', 'yes'],
-        'indentation': ['o', { 'Feature': 1, 'Background': 1, 'Scenario': 1, 'Step': 1, 'given': 1, 'and': 1}]
+        'rules': {
+          'no-files-without-scenarios': 'o',
+          'new-line-at-eof': ['o', 'yes'],
+          'indentation': ['o', { 'Feature': 1, 'Background': 1, 'Scenario': 1, 'Step': 1, 'given': 1, 'and': 1}]
+        }
       }), [
         'Invalid rule configuration for "no-files-without-scenarios" - The the config should be "on" or "off"',
         'Invalid rule configuration for "new-line-at-eof" - The first part of the config should be "on" or "off"',
@@ -55,11 +59,11 @@ describe('Config Verifier', function() {
     });
 
     it('an array configuration doesn\'t have exactly 2 parts', function() {
-      assert.deepEqual(verifyConfig({'new-line-at-eof': ['on']}), [
+      assert.deepEqual(verifyConfig({'rules': {'new-line-at-eof': ['on']}}), [
         'Invalid rule configuration for "new-line-at-eof" -  The config should only have 2 parts.'
       ]);
 
-      assert.deepEqual(verifyConfig({'new-line-at-eof': ['on', 'yes', 'p3']}), [
+      assert.deepEqual(verifyConfig({'rules': {'new-line-at-eof': ['on', 'yes', 'p3']}}), [
         'Invalid rule configuration for "new-line-at-eof" -  The config should only have 2 parts.'
       ]);
     });


### PR DESCRIPTION
This change will allow for future changes to the gherkinlint
configuration file for configuration of non-rule based features.

This relates to your suggestion to add an additionalRules configuration directive.

Let me know what you think. I haven’t added any backwards-compatibility.