### PR TITLE
Add support for Gherkin Rule in keywords-in-logical-order rule

### DIFF
--- a/src/rules/keywords-in-logical-order.js
+++ b/src/rules/keywords-in-logical-order.js
@@ -9,17 +9,25 @@ function run(feature) {
 
   let errors = [];
 
-  feature.children.forEach((child) => {
+  let simpleStepContainers = feature.children
+    .filter(child => child.background || child.scenario);
+
+  let ruleStepContainers = feature.children
+    .filter(child => child.rule)
+    .map(child => child.rule.children)
+    .flat();
+
+  let allStepContainers = simpleStepContainers.concat(ruleStepContainers);
+
+  allStepContainers.forEach(child => {
     const node = child.background || child.scenario;
+
     const keywordList = ['given', 'when', 'then'];
 
     let maxKeywordPosition = undefined;
 
     node.steps.forEach((step) => {
-      const keyword = gherkinUtils.getLanguageInsitiveKeyword(
-        step,
-        feature.language
-      );
+      const keyword = gherkinUtils.getLanguageInsitiveKeyword(step, feature.language);
       let keywordPosition = keywordList.indexOf(keyword);
 
       if (keywordPosition === -1) {
@@ -29,7 +37,6 @@ function run(feature) {
 
       if (keywordPosition < maxKeywordPosition) {
         let maxKeyword = keywordList[maxKeywordPosition];
-        // console.log(createError(step, maxKeyword));
         errors.push(createError(step, maxKeyword));
       }
 
@@ -43,12 +50,7 @@ function run(feature) {
 
 function createError(step, maxKeyword) {
   return {
-    message:
-      'Step "' +
-      step.keyword +
-      step.text +
-      '" should not appear after step using keyword ' +
-      maxKeyword,
+    message: `Step "${step.keyword}${step.text}" should not appear after step using keyword ${maxKeyword}`,
     rule: rule,
     line: step.location.line,
   };

--- a/test-data-wip/KeywordsInLogicalOrder.feature
+++ b/test-data-wip/KeywordsInLogicalOrder.feature
@@ -1,10 +1,15 @@
 Feature: Test for the keywords-in-logical-order rule
 
-Scenario: A scenario for keywords-in-logical-order rule
-  Then first then within scenario, which is fine
-  When a succeeding when step, which is bad
-  Given a succeeding given step, also bad
+  Scenario: A scenario for keywords-in-logical-order rule
+    Then first then within scenario, which is fine
+    When a succeeding when step, which is bad
+    Given a succeeding given step, also bad
 
-Scenario: Another scenario for keywords-in-logical-order rule
-  When a succeeding when step, which is okay
-  Given a succeeding given step, also bad
+  Scenario: Another scenario for keywords-in-logical-order rule
+    When a succeeding when step, which is okay
+    Given a succeeding given step, also bad
+
+  Rule: Scenarios in a rule should be checked, too
+    Scenario: Bad scenario in a Rule for keywords-in-logical-order rule
+      When a succeeding when step, which is okay
+      Given a succeeding given step, also bad

--- a/test/rules/keywords-in-logical-order/NoViolationsUsingRules.feature
+++ b/test/rules/keywords-in-logical-order/NoViolationsUsingRules.feature
@@ -1,0 +1,39 @@
+Feature: Feature with no keywords-in-logical-order violations, with file that uses gherkin rules
+
+Rule: This is a rule
+
+Background:
+  Given step4
+  And step5
+  And step6
+  When step7
+  And step8
+  And step9
+  Then step10
+  And step11
+  And step12
+
+Scenario: This is a Scenario
+  Given step15
+  And step16
+  And step17
+  When step18
+  And step19
+  And step20
+  Then step21
+  And step22
+  And step23
+
+Scenario Outline: This is a Scenario Outline
+  Given step26
+  And step27
+  And step28
+  When step29
+  And step30
+  And step31
+  Then step32
+  And step33
+  And step34
+Examples:
+  | foo |
+  | bar |

--- a/test/rules/keywords-in-logical-order/ViolationsUsingRules.feature
+++ b/test/rules/keywords-in-logical-order/ViolationsUsingRules.feature
@@ -1,6 +1,6 @@
-Feature: Feature with keywords-in-logical-order violations
-  Using whitespace so that line numbers of errors are the same
-  in this file and ViolationsUsingRules.feature
+Feature: Feature with keywords-in-logical-order violations, with file that uses gherkin rules
+
+Rule: This is a rule
 
 Background: All violations
   Then step1

--- a/test/rules/keywords-in-logical-order/keywords-in-logical-order.js
+++ b/test/rules/keywords-in-logical-order/keywords-in-logical-order.js
@@ -4,44 +4,54 @@ var runTest = ruleTestBase.createRuleTest(rule,
   'Step "<%= keyword %> <%= text %>" should not appear after step using keyword <%= priorKeyword %>');
 
 describe('Keywords in logical order', function() {
-  it('doesn\'t raise errors when there are no violations', function() {
+  it('doesn\'t raise errors when there are no violations, for file not using gherkin rules', function() {
     return runTest('keywords-in-logical-order/NoViolations.feature', {}, []);
   });
 
-  it('raises errors when there are violations', function() {
-    return runTest('keywords-in-logical-order/Violations.feature', {}, [
-      {
-        messageElements: { keyword: 'When', text: 'step2', priorKeyword: 'then'},
-        line: 5
-      },
-      {
-        messageElements: { keyword: 'Given', text: 'step3', priorKeyword: 'then'},
-        line: 6
-      },
-      {
-        messageElements: { keyword: 'Given', text: 'step12', priorKeyword: 'when'},
-        line: 10
-      },
-      {
-        messageElements: { keyword: 'Given', text: 'step22', priorKeyword: 'then'},
-        line: 14
-      },
-      {
-        messageElements: { keyword: 'When', text: 'step32', priorKeyword: 'then'},
-        line: 18
-      },
-      {
-        messageElements: { keyword: 'When', text: 'step54', priorKeyword: 'then'},
-        line: 24
-      },
-      {
-        messageElements: { keyword: 'When', text: 'step42', priorKeyword: 'then'},
-        line: 28
-      },
-      {
-        messageElements: { keyword: 'Given', text: 'step43', priorKeyword: 'then'},
-        line: 29
-      },
-    ]);
+  it('doesn\'t raise errors when there are no violations, for file that uses gherkin rules', function() {
+    return runTest('keywords-in-logical-order/NoViolationsUsingRules.feature', {}, []);
+  });
+
+  let expectedViolations = [
+    {
+      messageElements: { keyword: 'When', text: 'step2', priorKeyword: 'then'},
+      line: 7
+    },
+    {
+      messageElements: { keyword: 'Given', text: 'step3', priorKeyword: 'then'},
+      line: 8
+    },
+    {
+      messageElements: { keyword: 'Given', text: 'step12', priorKeyword: 'when'},
+      line: 12
+    },
+    {
+      messageElements: { keyword: 'Given', text: 'step22', priorKeyword: 'then'},
+      line: 16
+    },
+    {
+      messageElements: { keyword: 'When', text: 'step32', priorKeyword: 'then'},
+      line: 20
+    },
+    {
+      messageElements: { keyword: 'When', text: 'step54', priorKeyword: 'then'},
+      line: 26
+    },
+    {
+      messageElements: { keyword: 'When', text: 'step42', priorKeyword: 'then'},
+      line: 30
+    },
+    {
+      messageElements: { keyword: 'Given', text: 'step43', priorKeyword: 'then'},
+      line: 31
+    },
+  ];
+
+  it('raises errors when there are violations, for file not using gherkin rules', function() {
+    return runTest('keywords-in-logical-order/Violations.feature', {}, expectedViolations);
+  });
+
+  it('raises errors when there are violations, for file that uses gherkin rules', function() {
+    return runTest('keywords-in-logical-order/ViolationsUsingRules.feature', {}, expectedViolations);
   });
 });


### PR DESCRIPTION
* Add handling in keywords-in-logical-order for backgrounds and scenarios that are contained within a gherkin Rule
* Add supporting test cases
* Cleanup rules/keywords-in-logical-order.js

Addresses https://github.com/vsiakka/gherkin-lint/issues/252