### PR TITLE
feat() Improve console output using stylish

### DIFF
--- a/src/formatters/stylish.js
+++ b/src/formatters/stylish.js
@@ -19,17 +19,23 @@ function stylizeFilePath(filePath) {
 function stylizeError(error, maxLineLength, maxMessageLength, addColors) {
   const indent = '  '; // indent 2 spaces so it looks pretty
   const padding = '    '; //padding of 4 spaces, will be used between line numbers, error msgs and rule names, for readability
-  const errorLinePadded = error.line.toString().padEnd(maxLineLength);
-  const errorLineStylized = addColors ? style.gray(errorLinePadded) : errorLinePadded;
+  const errorLocation = getLocationString(error);
+  const errorLocationPadded = errorLocation.padEnd(maxLineLength);
+  const errorLocationStylized = addColors ? style.gray(errorLocationPadded) : errorLocationPadded;
+  const level = 'error'; // forced as levels are not implemented.
 
   const errorRuleStylized = addColors ? style.gray(error.rule) : error.rule;
-  return indent + errorLineStylized + padding + error.message.padEnd(maxMessageLength) + padding + errorRuleStylized;
+  return indent + errorLocationStylized + padding + level + padding + error.message.padEnd(maxMessageLength) + padding + errorRuleStylized;
 }
 
-function getMaxLineLength(result) {
+function getLocationString(loc) {
+  return `${loc.line}:${loc.column ? loc.column : '0'}`;
+}
+
+function getMaxLocationLength(result) {
   let length = 0;
   result.errors.forEach(error => {
-    const errorStr = error.line.toString();
+    const errorStr = getLocationString(error);
     if (errorStr.length > length) {
       length = errorStr.length;
     }
@@ -64,7 +70,7 @@ function printResults(results) {
 
   results.forEach(result => {
     if (result.errors.length > 0) {
-      const maxLineLength = getMaxLineLength(result);
+      const maxLineLength = getMaxLocationLength(result);
       const maxMessageLength = getMaxMessageLength(result, maxLineLength, consoleWidth);
       console.error(stylizeFilePath(result.filePath));
 

--- a/src/linter.js
+++ b/src/linter.js
@@ -17,7 +17,7 @@ function readAndParseFile(filePath) {
     };
 
     const stream = Gherkin.fromPaths([filePath], options);
-    
+
     stream.on('data', envelope => {
       if (envelope.attachment) {
         // An attachment implies that there was a parsing error
@@ -38,9 +38,9 @@ function readAndParseFile(filePath) {
       reject(processFatalErrors(error));
     });
 
-    stream.on('end', () => { 
+    stream.on('end', () => {
       if (parsingErrors.length) {
-        // Process all errors/attachments at once, because a tag on a background will 
+        // Process all errors/attachments at once, because a tag on a background will
         // generate multiple error events, and it would be confusing to print a message for each
         // one of them, when they are all caused by a single cause
         reject(processFatalErrors(parsingErrors));
@@ -64,17 +64,17 @@ function lint(files, configuration, additionalRulesDirs) {
 
     return readAndParseFile(f)
       .then(
-        // Handle Promise.resolve 
+        // Handle Promise.resolve
         ({feature, file}) => {
           perFileErrors = rules.runAllEnabledRules(feature, file, configuration, additionalRulesDirs);
         },
-        // Handle Promise.reject 
+        // Handle Promise.reject
         (parsingErrors) => {
           perFileErrors = parsingErrors;
         })
       .finally(()=> {
         let fileBlob = {
-          filePath: fs.realpathSync(f), 
+          filePath: fs.realpathSync(f),
           errors: _.sortBy(perFileErrors, 'line')
         };
 
@@ -105,7 +105,8 @@ function getFormatedTaggedBackgroundError(errors) {
     errorMsgs.push({
       message: 'Tags on Backgrounds are dissallowed',
       rule: 'no-tags-on-backgrounds',
-      line: errors[0].data.match(/\((\d+):.*/)[1]
+      line: errors[0].data.match(/\((\d+):.*/)[1],
+      column: 0
     });
 
     index = 2;
@@ -143,9 +144,12 @@ function getFormattedFatalError(error) {
     errorMsg = error.data;
     rule = 'unexpected-error';
   }
-  return {message: errorMsg,
+  return {
+    message: errorMsg,
     rule   : rule,
-    line   : errorLine};
+    line   : errorLine,
+    column: 0
+  };
 }
 
 module.exports = {

--- a/src/rules/allowed-tags.js
+++ b/src/rules/allowed-tags.js
@@ -26,7 +26,7 @@ function run(feature, unused, configuration) {
           checkTags(example, allowedTags, allowedPatterns, errors);
         });
       }
-    }      
+    }
   });
 
   return errors;
@@ -53,7 +53,8 @@ function createError(node, tag) {
   return {
     message: 'Not allowed tag ' + tag.name + ' on ' + node.keyword,
     rule   : rule,
-    line   : tag.location.line
+    line   : tag.location.line,
+    column : tag.location.column,
   };
 }
 

--- a/src/rules/file-name.js
+++ b/src/rules/file-name.js
@@ -29,7 +29,8 @@ function run(feature, file, configuration) {
   return [{
     message: `File names should be written in ${style} e.g. "${expected}.feature"`,
     rule: rule,
-    line: 0
+    line: 0,
+    column: 0
   }];
 }
 

--- a/src/rules/indentation.js
+++ b/src/rules/indentation.js
@@ -51,7 +51,8 @@ function run(feature, unused, configuration) {
                             '", expected indentation level of ' + mergedConfiguration[type] +
                             ', but got ' + (parsedLocation.column - 1),
         rule   : rule,
-        line   : parsedLocation.line
+        line   : parsedLocation.line,
+        column : parsedLocation.column,
       });
     }
   }

--- a/src/rules/keywords-in-logical-order.js
+++ b/src/rules/keywords-in-logical-order.js
@@ -51,6 +51,7 @@ function createError(step, maxKeyword) {
       maxKeyword,
     rule: rule,
     line: step.location.line,
+    column: step.location.column,
   };
 }
 

--- a/src/rules/max-scenarios-per-file.js
+++ b/src/rules/max-scenarios-per-file.js
@@ -32,7 +32,8 @@ function run(feature, unused, config) {
     errors.push({
       message: 'Number of scenarios exceeds maximum: ' + count + '/' + maxScenarios,
       rule,
-      line: 0
+      line: 0,
+      column: 0
     });
   }
 

--- a/src/rules/name-length.js
+++ b/src/rules/name-length.js
@@ -14,7 +14,9 @@ function test(name, location, configuration, type) {
   if (name && (name.length > configuration[type])) {
     errors.push({message: type + ' name is too long. Length of ' + name.length + ' is longer than the maximum allowed: ' + configuration[type],
       rule   : rule,
-      line   : location.line});
+      line   : location.line,
+      column : location.column,
+    });
   }
 }
 
@@ -32,11 +34,11 @@ function run(feature, unused, configuration) {
 
   errors = [];
   const mergedConfiguration = _.merge(availableConfigs, configuration);
-  
+
   // Check Feature name length
   test(feature.name, feature.location, mergedConfiguration, 'Feature');
 
-  feature.children.forEach(child => { 
+  feature.children.forEach(child => {
     if (child.rule) {
       test(child.rule.name, child.rule.location, mergedConfiguration, 'Rule');
     } else if (child.background) {

--- a/src/rules/new-line-at-eof.js
+++ b/src/rules/new-line-at-eof.js
@@ -13,7 +13,7 @@ function run(unused, file, configuration) {
     logger.boldError(rule + ' requires an extra configuration value.\nAvailable configurations: ' + availableConfigs.join(', ') + '\nFor syntax please look at the documentation.');
     process.exit(1);
   }
-  
+
   const hasNewLineAtEOF = _.last(file.lines) === '';
   let errormsg = '';
   if (hasNewLineAtEOF && configuration === 'no') {
@@ -26,7 +26,8 @@ function run(unused, file, configuration) {
     errors.push({
       message: errormsg,
       rule   : rule,
-      line   : file.lines.length
+      line   : file.lines.length,
+      column : 0
     });
   }
 

--- a/src/rules/no-background-only-scenario.js
+++ b/src/rules/no-background-only-scenario.js
@@ -6,7 +6,7 @@ function run(feature) {
   }
 
   let errors = [];
-  
+
   feature.children.forEach(child => {
     if (child.background) {
       if (feature.children.length <= 2) {
@@ -24,7 +24,9 @@ function createError(background) {
   return {
     message: 'Backgrounds are not allowed when there is just one scenario.',
     rule   : rule,
-    line   : background.location.line};
+    line   : background.location.line,
+    column : background.location.column,
+  };
 }
 
 module.exports = {

--- a/src/rules/no-dupe-feature-names.js
+++ b/src/rules/no-dupe-feature-names.js
@@ -12,12 +12,13 @@ function run(feature, file) {
     errors.push({
       message: 'Feature name is already used in: ' + dupes,
       rule   : rule,
-      line   : feature.location.line
+      line   : feature.location.line,
+      column : feature.location.column,
     });
   } else {
     features[feature.name] = {files: [file.relativePath]};
   }
-  
+
   return errors;
 }
 

--- a/src/rules/no-dupe-scenario-names.js
+++ b/src/rules/no-dupe-scenario-names.js
@@ -20,29 +20,33 @@ function run(feature, file, configuration) {
     if (child.scenario) {
       if (child.scenario.name in scenarios) {
         const dupes = getFileLinePairsAsStr(scenarios[child.scenario.name].locations);
-        
+
         scenarios[child.scenario.name].locations.push({
-          file: file.relativePath, 
-          line: child.scenario.location.line
+          file: file.relativePath,
+          line: child.scenario.location.line,
+          column: child.scenario.location.column,
         });
 
         errors.push({
           message: 'Scenario name is already used in: ' + dupes,
           rule   : rule,
-          line   : child.scenario.location.line});
+          line   : child.scenario.location.line,
+          column : child.scenario.location.column,
+        });
       } else {
         scenarios[child.scenario.name] = {
           locations: [
             {
-              file: file.relativePath, 
-              line: child.scenario.location.line
+              file: file.relativePath,
+              line: child.scenario.location.line,
+              column: child.scenario.location.column,
             }
           ]
         };
       }
     }
   });
-  
+
   return errors;
 }
 

--- a/src/rules/no-duplicate-tags.js
+++ b/src/rules/no-duplicate-tags.js
@@ -28,7 +28,9 @@ function verifyTags(node, errors) {
       if (_.includes(uniqueTagNames, tag.name)) {
         errors.push({message: 'Duplicate tags are not allowed: ' + tag.name,
           rule   : rule,
-          line   : tag.location.line});
+          line   : tag.location.line,
+          column : tag.location.column,
+        });
         failedTagNames.push(tag.name);
       } else  {
         uniqueTagNames.push(tag.name);

--- a/src/rules/no-empty-background.js
+++ b/src/rules/no-empty-background.js
@@ -21,7 +21,9 @@ function createError(background) {
   return {
     message: 'Empty backgrounds are not allowed.',
     rule   : rule,
-    line   : background.location.line
+    line   : background.location.line,
+    column : background.location.column,
+
   };
 }
 

--- a/src/rules/no-empty-file.js
+++ b/src/rules/no-empty-file.js
@@ -7,7 +7,8 @@ function run(feature) {
     errors.push({
       message: 'Empty feature files are disallowed',
       rule   : rule,
-      line   : 1
+      line   : 1,
+      column: 0
     });
   }
   return errors;

--- a/src/rules/no-examples-in-scenarios.js
+++ b/src/rules/no-examples-in-scenarios.js
@@ -9,12 +9,13 @@ function run(feature) {
   feature.children.forEach((child) => {
     if (child.scenario) {
       const nodeType = gherkinUtils.getNodeType(child.scenario, feature.language);
-      
+
       if (nodeType == 'Scenario' && child.scenario.examples.length) {
         errors.push({
           message: 'Cannot use "Examples" in a "Scenario", use a "Scenario Outline" instead',
           rule   : rule,
           line   : child.scenario.location.line,
+          column : child.scenario.location.column,
         });
       }
     }

--- a/src/rules/no-files-without-scenarios.js
+++ b/src/rules/no-files-without-scenarios.js
@@ -13,7 +13,8 @@ function run(feature) {
     errors.push({
       message: 'Feature file does not have any Scenarios',
       rule   : rule,
-      line   : 1
+      line   : 1,
+      column: 0
     });
   }
   return errors;

--- a/src/rules/no-homogenous-tags.js
+++ b/src/rules/no-homogenous-tags.js
@@ -8,7 +8,7 @@ function run(feature) {
   }
   let errors = [];
 
-  // Tags that exist in every scenario and scenario outline 
+  // Tags that exist in every scenario and scenario outline
   // should be applied on a feature level
   let childrenTags = [];
 
@@ -27,26 +27,28 @@ function run(feature) {
       if (homogenousExampleTags.length) {
         errors.push({
           message: 'All Examples of a Scenario Outline have the same tag(s), ' +
-            'they should be defined on the Scenario Outline instead: ' + 
+            'they should be defined on the Scenario Outline instead: ' +
             homogenousExampleTags.join(', '),
           rule: rule,
-          line: scenario.location.line
+          line: scenario.location.line,
+          column: scenario.location.column,
         });
       }
-    }    
+    }
   });
 
   const homogenousTags = _.intersection(...childrenTags);
   if (homogenousTags.length) {
     errors.push({
       message: 'All Scenarios on this Feature have the same tag(s), ' +
-        'they should be defined on the Feature instead: ' + 
+        'they should be defined on the Feature instead: ' +
         homogenousTags.join(', '),
       rule   : rule,
-      line   : feature.location.line
+      line   : feature.location.line,
+      column : feature.location.column,
     });
   }
-  
+
   return errors;
 }
 

--- a/src/rules/no-multiple-empty-lines.js
+++ b/src/rules/no-multiple-empty-lines.js
@@ -6,7 +6,9 @@ function run(unused, file) {
     if (file.lines[i].trim() === '' && file.lines[i + 1].trim() == '') {
       errors.push({message: 'Multiple empty lines are not allowed',
         rule   : rule,
-        line   : i + 2});
+        line   : i + 2,
+        column : 0,
+      });
     }
   }
   return errors;

--- a/src/rules/no-partially-commented-tag-lines.js
+++ b/src/rules/no-partially-commented-tag-lines.js
@@ -17,7 +17,7 @@ function run(feature) {
       });
     }
   });
-  
+
   return errors;
 }
 
@@ -27,7 +27,8 @@ function checkTags(node, errors) {
       errors.push({
         message: 'Partially commented tag lines not allowed',
         rule   : rule,
-        line   : tag.location.line
+        line   : tag.location.line,
+        column : tag.location.column,
       });
     }
   });

--- a/src/rules/no-restricted-patterns.js
+++ b/src/rules/no-restricted-patterns.js
@@ -44,7 +44,7 @@ function getRestrictedPatterns(configuration) {
   Object.keys(availableConfigs).forEach(key => {
     const resolvedKey = key.toLowerCase().replace(/ /g, '');
     const resolvedConfig = (configuration[key] || []);
-    
+
     restrictedPatterns[resolvedKey] = resolvedConfig.map(pattern => new RegExp(pattern, 'i'));
 
     restrictedPatterns[resolvedKey] = restrictedPatterns[resolvedKey].concat(globalPatterns);
@@ -88,14 +88,14 @@ function check(node, property, pattern, language, errors) {
   const type = gherkinUtils.getNodeType(node, language);
 
   if (property == 'description') {
-    // Descriptions can be multiline, in which case the description will contain escapted 
+    // Descriptions can be multiline, in which case the description will contain escapted
     // newline characters "\n". If a multiline description matches one of the restricted patterns
     // when the error message gets printed in the console, it will break the message into multiple lines.
     // So let's split the description on newline chars and test each line separately.
 
-    // To make sure we don't accidentally pick up a doubly escaped new line "\\n" which would appear 
-    // if a user wrote the string "\n" in a description, let's replace all escaped new lines 
-    // with a sentinel, split lines and then restore the doubly escaped new line 
+    // To make sure we don't accidentally pick up a doubly escaped new line "\\n" which would appear
+    // if a user wrote the string "\n" in a description, let's replace all escaped new lines
+    // with a sentinel, split lines and then restore the doubly escaped new line
     const escapedNewLineSentinel = '<!gherkin-lint new line sentinel!>';
     const escapedNewLine = '\\n';
     strings = node[property]
@@ -103,18 +103,19 @@ function check(node, property, pattern, language, errors) {
       .split('\n')
       .map(string => string.replace(escapedNewLineSentinel, escapedNewLine));
   }
-  
+
   for (let i = 0; i < strings.length; i++) {
-    // We use trim() on the examined string because names and descriptions can contain 
+    // We use trim() on the examined string because names and descriptions can contain
     // white space before and after, unlike steps
     if (strings[i].trim().match(pattern)) {
       errors.push({
         message: `${type} ${property}: "${strings[i].trim()}" matches restricted pattern "${pattern}"`,
         rule: rule,
-        line: node.location.line
+        line: node.location.line,
+        column: node.location.column,
       });
     }
-  } 
+  }
 }
 
 

--- a/src/rules/no-restricted-tags.js
+++ b/src/rules/no-restricted-tags.js
@@ -12,14 +12,14 @@ function run(feature, unused, configuration) {
   if (!feature) {
     return [];
   }
-  
+
   const forbiddenTags = configuration.tags;
   const forbiddenPatterns = getForbiddenPatterns(configuration);
   const language = feature.language;
   let errors = [];
 
   checkTags(feature, language, forbiddenTags, forbiddenPatterns, errors);
-  
+
   feature.children.forEach(child => {
     // backgrounds don't have tags
     if (child.scenario) {
@@ -28,9 +28,9 @@ function run(feature, unused, configuration) {
       child.scenario.examples.forEach(example => {
         checkTags(example, language, forbiddenTags, forbiddenPatterns, errors);
       });
-    }      
+    }
   });
-  
+
   return errors;
 }
 
@@ -47,7 +47,8 @@ function checkTags(node, language, forbiddenTags, forbiddenPatterns, errors) {
       errors.push({
         message: `Forbidden tag ${tag.name} on ${nodeType}`,
         rule   : rule,
-        line   : tag.location.line
+        line   : tag.location.line,
+        column : tag.location.column,
       });
     }
   });

--- a/src/rules/no-scenario-outlines-without-examples.js
+++ b/src/rules/no-scenario-outlines-without-examples.js
@@ -16,12 +16,13 @@ function run(feature) {
         errors.push({
           message: 'Scenario Outline does not have any Examples',
           rule   : rule,
-          line   : scenario.location.line
+          line   : scenario.location.line,
+          column : scenario.location.column,
         });
       }
     }
   });
-  return errors;  
+  return errors;
 }
 
 module.exports = {

--- a/src/rules/no-superfluous-tags.js
+++ b/src/rules/no-superfluous-tags.js
@@ -33,7 +33,8 @@ function checkTags(child, parent, language, errors) {
     errors.push({
       message: `Tag duplication between ${childType} and its corresponding ${parentType}: ${tag.name}`,
       rule   : rule,
-      line   : tag.location.line
+      line   : tag.location.line,
+      column   : tag.location.column,
     });
   });
 }

--- a/src/rules/no-trailing-spaces.js
+++ b/src/rules/no-trailing-spaces.js
@@ -7,12 +7,14 @@ function run(unused, file) {
     if (/[\t ]+$/.test(line)) {
       errors.push({message: 'Trailing spaces are not allowed',
         rule   : rule,
-        line   : lineNo});
+        line   : lineNo,
+        column : 0,
+      });
     }
 
     lineNo++;
   });
-  
+
   return errors;
 }
 

--- a/src/rules/no-unnamed-features.js
+++ b/src/rules/no-unnamed-features.js
@@ -4,11 +4,12 @@ function run(feature) {
   let errors = [];
 
   if (!feature || !feature.name) {
-    const location = feature ? feature.location.line : 0;
+    const location = feature ? feature.location : {line: 0, column: 0};
     errors.push({
       message: 'Missing Feature name',
       rule   : rule,
-      line   : location
+      line   : location.line,
+      column : location.column,
     });
   }
   return errors;

--- a/src/rules/no-unnamed-scenarios.js
+++ b/src/rules/no-unnamed-scenarios.js
@@ -10,7 +10,9 @@ function run(feature) {
       errors.push({
         message: 'Missing Scenario name',
         rule   : rule,
-        line   : child.scenario.location.line});
+        line   : child.scenario.location.line,
+        column : child.scenario.location.column,
+      });
     }
   });
   return errors;

--- a/src/rules/one-space-between-tags.js
+++ b/src/rules/one-space-between-tags.js
@@ -7,9 +7,9 @@ function run(feature) {
     return;
   }
   let errors = [];
-  
+
   testTags(feature, errors);
-  
+
   feature.children.forEach(child => {
     if (child.scenario) {
       testTags(child.scenario, errors);
@@ -19,7 +19,7 @@ function run(feature) {
       });
     }
   });
-  
+
   return errors;
 }
 
@@ -33,6 +33,7 @@ function testTags(node, errors) {
           if (tags[i].location.column + tags[i].name.length < tags[i + 1].location.column - 1) {
             errors.push({
               line: tags[i].location.line,
+              column: tags[i].location.column,
               rule: rule,
               message: 'There is more than one space between the tags ' +
                         tags[i].name + ' and ' + tags[i + 1].name

--- a/src/rules/required-tags.js
+++ b/src/rules/required-tags.js
@@ -8,14 +8,15 @@ const availableConfigs = {
 };
 
 
-function checkTagExists(requiredTag, ignoreUntagged, scenarioTags, scenarioType, scenarioLine) {
+function checkTagExists(requiredTag, ignoreUntagged, scenarioTags, scenarioType, scenarioLocation) {
   const result = (ignoreUntagged && scenarioTags.length == 0)
     || scenarioTags.some((tagObj) => RegExp(requiredTag).test(tagObj.name));
   if (!result) {
     return {
       message: `No tag found matching ${requiredTag} for ${scenarioType}`,
       rule,
-      line: scenarioLine
+      line: scenarioLocation.line,
+      column: scenarioLocation.column,
     };
   }
   return result;
@@ -32,11 +33,11 @@ function run(feature, unused, config) {
   feature.children.forEach((child) => {
     if (child.scenario) {
       const type = gherkinUtils.getNodeType(child.scenario, feature.language);
-      const line = child.scenario.location.line;
+      const location = child.scenario.location;
 
       // Check each Scenario for the required tags
       const requiredTagErrors = mergedConfig.tags
-        .map((requiredTag) => checkTagExists(requiredTag, mergedConfig.ignoreUntagged, child.scenario.tags || [], type, line))
+        .map((requiredTag) => checkTagExists(requiredTag, mergedConfig.ignoreUntagged, child.scenario.tags || [], type, location))
         .filter((item) =>
           typeof item === 'object' && item.message
         );
@@ -45,7 +46,7 @@ function run(feature, unused, config) {
       errors = errors.concat(requiredTagErrors);
     }
   });
-  
+
   return errors;
 }
 

--- a/src/rules/scenario-size.js
+++ b/src/rules/scenario-size.js
@@ -30,7 +30,8 @@ function run(feature, unused, configuration) {
       errors.push({
         message: `Element ${nodeType} too long: actual ${node.steps.length}, expected ${maxSize}`,
         rule   : 'scenario-size',
-        line   : node.location.line
+        line   : node.location.line,
+        column   : node.location.column,
       });
     }
   });

--- a/src/rules/use-and.js
+++ b/src/rules/use-and.js
@@ -8,7 +8,7 @@ function run(feature) {
   }
 
   let errors = [];
-  
+
   feature.children.forEach(child => {
     const node = child.rule || child.background || child.scenario;
     let previousKeyword = undefined;
@@ -34,7 +34,8 @@ function createError(step) {
   return {
     message: 'Step "' + step.keyword + step.text + '" should use And instead of ' + step.keyword,
     rule   : rule,
-    line   : step.location.line
+    line   : step.location.line,
+    column : step.location.column,
   };
 }
 

--- a/test/linter/linter.js
+++ b/test/linter/linter.js
@@ -15,6 +15,7 @@ describe('Linter', function() {
     let feature = 'test/linter/MultipleBackgrounds.feature';
     let expected = [{
       'line': '9',
+      'column': 0,
       'message': 'Multiple "Background" definitions in the same file are disallowed',
       'rule': 'up-to-one-background-per-file'
     }];
@@ -25,10 +26,11 @@ describe('Linter', function() {
     let feature = 'test/linter/TagOnBackground.feature';
     let expected = [{
       'line': '4',
+      'column': 0,
       'message': 'Tags on Backgrounds are dissallowed',
       'rule': 'no-tags-on-backgrounds'
     }];
-    
+
     return linterTest(feature, expected);
   });
 
@@ -36,6 +38,7 @@ describe('Linter', function() {
     let feature = 'test/linter/MultipleFeatures.feature';
     let expected = [{
       'line': '7',
+      'column': 0,
       'message': 'Multiple "Feature" definitions in the same file are disallowed',
       'rule': 'one-feature-per-file'
     }];
@@ -46,6 +49,7 @@ describe('Linter', function() {
     let feature = 'test/linter/MultilineStep.feature';
     let expected = [{
       'line': '9',
+      'column': 0,
       'message': 'Steps should begin with "Given", "When", "Then", "And" or "But". Multiline steps are dissallowed',
       'rule': 'no-multiline-steps'
     }];
@@ -56,6 +60,7 @@ describe('Linter', function() {
     let feature = 'test/linter/MultilineBackgroundStep.feature';
     let expected = [{
       'line': '5',
+      'column': 0,
       'message': 'Steps should begin with "Given", "When", "Then", "And" or "But". Multiline steps are dissallowed',
       'rule': 'no-multiline-steps'
     }];
@@ -66,6 +71,7 @@ describe('Linter', function() {
     let feature = 'test/linter/MultilineScenarioOutlineStep.feature';
     let expected = [{
       'line': '9',
+      'column': 0,
       'message': 'Steps should begin with "Given", "When", "Then", "And" or "But". Multiline steps are dissallowed',
       'rule': 'no-multiline-steps'
     }];
@@ -74,27 +80,30 @@ describe('Linter', function() {
 
   it('detects additional violations that happen after the \'no-tags-on-backgrounds\' rule', function() {
     let feature = 'test/linter/MultipleViolations.feature';
-    let expected = [ 
-      { 
+    let expected = [
+      {
         message: 'Steps should begin with "Given", "When", "Then", "And" or "But". Multiline steps are dissallowed',
         rule: 'no-multiline-steps',
-        line: '13' },
-      { 
+        line: '13',
+        column: 0
+      },
+      {
         message: 'Tags on Backgrounds are dissallowed',
         rule: 'no-tags-on-backgrounds',
-        line: '4'
-      } 
+        line: '4',
+        column: 0
+      }
     ];
 
-    linter.lint([feature])
+    return linter.lint([feature])
       .then((actual) => {
         assert.deepEqual(actual[0].errors, expected);
-      });    
+      });
   });
 
   it('correctly parses files that have the correct Gherkin format', function() {
     let feature = 'test/linter/NoViolations.feature';
     let expected = [];
-    return linterTest(feature, expected);   
+    return linterTest(feature, expected);
   });
 });

--- a/test/rules/allowed-tags/allowed-tags.js
+++ b/test/rules/allowed-tags/allowed-tags.js
@@ -16,31 +16,38 @@ describe('Allowed Tags Rule', function() {
       'patterns': ['^@examplestag$']
     }, [{
       messageElements: {tags: '@featuretag1', nodeType:'Feature'},
-      line: 1
+      line: 1,
+      column: 13
     },
     {
       messageElements: {tags: '@anothertag', nodeType:'Feature'},
-      line: 1
+      line: 1,
+      column: 26
     },
     {
       messageElements: {tags: '@scenariotag1', nodeType:'Scenario'},
-      line: 7
+      line: 7,
+      column: 14
     },
     {
       messageElements: {tags: '@scenariotag2', nodeType:'Scenario'},
-      line: 7
+      line: 7,
+      column: 28
     },
     {
       messageElements: {tags: '@anothertag', nodeType:'Scenario'},
-      line: 7
+      line: 7,
+      column: 42
     },
     {
       messageElements: {tags: '@scenariotag1', nodeType:'Scenario Outline'},
-      line: 11
+      line: 11,
+      column: 14
     },
     {
       messageElements: {tags: '@examplestag1', nodeType:'Examples'},
-      line: 14
+      line: 14,
+      column: 14
     }]);
   });
 });

--- a/test/rules/file-name/file-name.js
+++ b/test/rules/file-name/file-name.js
@@ -15,7 +15,8 @@ describe('File Name Rule', function() {
         'style': 'kebab-case'
       }, [{
         messageElements: {style: 'kebab-case', corrected:'pascal-case-with-five-words.feature'},
-        line: 0
+        line: 0,
+        column: 0,
       }]);
     });
 
@@ -24,7 +25,8 @@ describe('File Name Rule', function() {
         'style': 'kebab-case'
       }, [{
         messageElements: {style: 'kebab-case', corrected:'title-case.feature'},
-        line: 0
+        line: 0,
+        column: 0,
       }]);
     });
 
@@ -33,7 +35,8 @@ describe('File Name Rule', function() {
         'style': 'kebab-case'
       }, [{
         messageElements: {style: 'kebab-case', corrected:'camel-case.feature'},
-        line: 0
+        line: 0,
+        column: 0,
       }]);
     });
 
@@ -42,7 +45,8 @@ describe('File Name Rule', function() {
         'style': 'kebab-case'
       }, [{
         messageElements: {style: 'kebab-case', corrected:'snake-case.feature'},
-        line: 0
+        line: 0,
+        column: 0,
       }]);
     });
   });
@@ -59,7 +63,8 @@ describe('File Name Rule', function() {
         'style': 'camelCase'
       }, [{
         messageElements: {style: 'camelCase', corrected:'pascalCaseWithFiveWords.feature'},
-        line: 0
+        line: 0,
+        column: 0,
       }]);
     });
 
@@ -68,7 +73,8 @@ describe('File Name Rule', function() {
         'style': 'camelCase'
       }, [{
         messageElements: {style: 'camelCase', corrected:'titleCase.feature'},
-        line: 0
+        line: 0,
+        column: 0,
       }]);
     });
 
@@ -77,7 +83,8 @@ describe('File Name Rule', function() {
         'style': 'camelCase'
       }, [{
         messageElements: {style: 'camelCase', corrected:'kebabCase.feature'},
-        line: 0
+        line: 0,
+        column: 0,
       }]);
     });
 
@@ -86,7 +93,8 @@ describe('File Name Rule', function() {
         'style': 'camelCase'
       }, [{
         messageElements: {style: 'camelCase', corrected:'snakeCase.feature'},
-        line: 0
+        line: 0,
+        column: 0,
       }]);
     });
   });
@@ -103,7 +111,8 @@ describe('File Name Rule', function() {
         'style': 'PascalCase'
       }, [{
         messageElements: {style: 'PascalCase', corrected:'KebabCase.feature'},
-        line: 0
+        line: 0,
+        column: 0,
       }]);
     });
 
@@ -112,7 +121,8 @@ describe('File Name Rule', function() {
         'style': 'PascalCase'
       }, [{
         messageElements: {style: 'PascalCase', corrected:'TitleCase.feature'},
-        line: 0
+        line: 0,
+        column: 0,
       }]);
     });
 
@@ -121,7 +131,8 @@ describe('File Name Rule', function() {
         'style': 'PascalCase'
       }, [{
         messageElements: {style: 'PascalCase', corrected:'CamelCase.feature'},
-        line: 0
+        line: 0,
+        column: 0,
       }]);
     });
 
@@ -130,7 +141,8 @@ describe('File Name Rule', function() {
         'style': 'PascalCase'
       }, [{
         messageElements: {style: 'PascalCase', corrected:'SnakeCase.feature'},
-        line: 0
+        line: 0,
+        column: 0,
       }]);
     });
   });
@@ -147,7 +159,8 @@ describe('File Name Rule', function() {
         'style': 'Title Case'
       }, [{
         messageElements: {style: 'Title Case', corrected:'Kebab Case.feature'},
-        line: 0
+        line: 0,
+        column: 0,
       }]);
     });
 
@@ -156,7 +169,8 @@ describe('File Name Rule', function() {
         'style': 'Title Case'
       }, [{
         messageElements: {style: 'Title Case', corrected:'Pascal Case With Five Words.feature'},
-        line: 0
+        line: 0,
+        column: 0,
       }]);
     });
 
@@ -165,7 +179,8 @@ describe('File Name Rule', function() {
         'style': 'Title Case'
       }, [{
         messageElements: {style: 'Title Case', corrected:'Camel Case.feature'},
-        line: 0
+        line: 0,
+        column: 0,
       }]);
     });
 
@@ -174,7 +189,8 @@ describe('File Name Rule', function() {
         'style': 'Title Case'
       }, [{
         messageElements: {style: 'Title Case', corrected:'Snake Case.feature'},
-        line: 0
+        line: 0,
+        column: 0,
       }]);
     });
   });
@@ -191,7 +207,8 @@ describe('File Name Rule', function() {
         'style': 'snake_case'
       }, [{
         messageElements: {style: 'snake_case', corrected:'pascal_case_with_five_words.feature'},
-        line: 0
+        line: 0,
+        column: 0,
       }]);
     });
 
@@ -200,7 +217,8 @@ describe('File Name Rule', function() {
         'style': 'snake_case'
       }, [{
         messageElements: {style: 'snake_case', corrected:'title_case.feature'},
-        line: 0
+        line: 0,
+        column: 0,
       }]);
     });
 
@@ -209,7 +227,8 @@ describe('File Name Rule', function() {
         'style': 'snake_case'
       }, [{
         messageElements: {style: 'snake_case', corrected:'camel_case.feature'},
-        line: 0
+        line: 0,
+        column: 0,
       }]);
     });
 
@@ -218,7 +237,8 @@ describe('File Name Rule', function() {
         'style': 'snake_case'
       }, [{
         messageElements: {style: 'snake_case', corrected:'kebab_case.feature'},
-        line: 0
+        line: 0,
+        column: 0,
       }]);
     });
   });

--- a/test/rules/indentation/indentation.js
+++ b/test/rules/indentation/indentation.js
@@ -5,49 +5,64 @@ var runTest = ruleTestBase.createRuleTest(rule,
 
 var wrongIndenatationErrors = [{
   messageElements: {element: 'Feature', expected: 0, actual: 1},
-  line: 2
+  line: 2,
+  column: 2,
 },{
   messageElements: {element: 'feature tag', expected: 0, actual: 1},
-  line: 1
+  line: 1,
+  column: 2,
 },{
   messageElements: {element: 'Background', expected: 0, actual: 4},
-  line: 4
+  line: 4,
+  column: 5,
 },{
   messageElements: {element: 'Step', expected: 2, actual: 0},
-  line: 5
+  line: 5,
+  column: 1,
 },{
   messageElements: {element: 'Scenario', expected: 0, actual: 1},
-  line: 9
+  line: 9,
+  column: 2,
 },{
   messageElements: {element: 'scenario tag', expected: 0, actual: 1},
-  line: 7
+  line: 7,
+  column: 2,
 },{
   messageElements: {element: 'scenario tag', expected: 0, actual: 1},
-  line: 8
+  line: 8,
+  column: 2,
 },{
   messageElements: {element: 'Step', expected: 2, actual: 3},
-  line: 10
+  line: 10,
+  column: 4,
 },{
   messageElements: {element: 'Scenario', expected: 0, actual: 3},
-  line: 14
-},{
-  messageElements: {element: 'Examples', expected: 0, actual: 2},
-  line: 16
-},{
-  messageElements: {element: 'example', expected: 2, actual: 4},
-  line: 17
-},{
-  messageElements: {element: 'example', expected: 2, actual: 4},
-  line: 18
+  line: 14,
+  column: 4,
 },{
   messageElements: {element: 'scenario tag', expected: 0, actual: 3},
-  line: 12
+  line: 12,
+  column: 4,
 },{
   messageElements: {element: 'scenario tag', expected: 0, actual: 4},
-  line: 13
+  line: 13,
+  column: 5,
 },{
   messageElements: {element: 'Step', expected: 2, actual: 3},
-  line: 15
+  line: 15,
+  column: 4,
+},{
+  messageElements: {element: 'Examples', expected: 0, actual: 2},
+  line: 16,
+  column: 3,
+},{
+  messageElements: {element: 'example', expected: 2, actual: 4},
+  line: 17,
+  column: 5,
+},{
+  messageElements: {element: 'example', expected: 2, actual: 4},
+  line: 18,
+  column: 5,
 }];
 
 describe('Indentation rule', function() {
@@ -70,49 +85,64 @@ describe('Indentation rule', function() {
   it('detects errors for features, backgrounds, scenarios, scenario outlines and steps in other languages', function() {
     return runTest('indentation/WrongIndentationDifferentLanguage.feature', {}, [{
       messageElements: {element: 'Feature', expected: 0, actual: 4},
-      line: 3
+      line: 3,
+      column: 5,
     },{
       messageElements: {element: 'feature tag', expected: 0, actual: 4},
-      line: 2
+      line: 2,
+      column: 5,
     },{
       messageElements: {element: 'Background', expected: 0, actual: 4},
-      line: 5
+      line: 5,
+      column: 5,
     },{
       messageElements: {element: 'Step', expected: 2, actual: 0},
-      line: 6
+      line: 6,
+      column: 1,
     },{
       messageElements: {element: 'Scenario', expected: 0, actual: 4},
-      line: 10
+      line: 10,
+      column: 5,
     },{
       messageElements: {element: 'scenario tag', expected: 0, actual: 4},
-      line: 8
+      line: 8,
+      column: 5,
     },{
       messageElements: {element: 'scenario tag', expected: 0, actual: 1},
-      line: 9
+      line: 9,
+      column: 2,
     },{
       messageElements: {element: 'Step', expected: 2, actual: 12},
-      line: 11
+      line: 11,
+      column: 13,
     },{
       messageElements: {element: 'Scenario', expected: 0, actual: 12},
-      line: 15
-    },{
-      messageElements: {element: 'Examples', expected: 0, actual: 7},
-      line: 17
-    },{
-      messageElements: {element: 'example', expected: 2, actual: 15},
-      line: 18
-    },{
-      messageElements: {element: 'example', expected: 2, actual: 15},
-      line: 19
+      line: 15,
+      column: 13,
     },{
       messageElements: {element: 'scenario tag', expected: 0, actual: 4},
-      line: 13
+      line: 13,
+      column: 5,
     },{
       messageElements: {element: 'scenario tag', expected: 0, actual: 1},
-      line: 14
+      line: 14,
+      column: 2,
     },{
       messageElements: {element: 'Step', expected: 2, actual: 11},
-      line: 16
+      line: 16,
+      column: 12,
+    },{
+      messageElements: {element: 'Examples', expected: 0, actual: 7},
+      line: 17,
+      column: 8,
+    },{
+      messageElements: {element: 'example', expected: 2, actual: 15},
+      line: 18,
+      column: 16,
+    },{
+      messageElements: {element: 'example', expected: 2, actual: 15},
+      line: 19,
+      column: 16,
     }]);
   });
 

--- a/test/rules/keywords-in-logical-order/keywords-in-logical-order.js
+++ b/test/rules/keywords-in-logical-order/keywords-in-logical-order.js
@@ -12,35 +12,43 @@ describe('Keywords in logical order', function() {
     return runTest('keywords-in-logical-order/Violations.feature', {}, [
       {
         messageElements: { keyword: 'When', text: 'step2', priorKeyword: 'then'},
-        line: 5
+        line: 5,
+        column: 3,
       },
       {
         messageElements: { keyword: 'Given', text: 'step3', priorKeyword: 'then'},
-        line: 6
+        line: 6,
+        column: 3,
       },
       {
         messageElements: { keyword: 'Given', text: 'step12', priorKeyword: 'when'},
-        line: 10
+        line: 10,
+        column: 3,
       },
       {
         messageElements: { keyword: 'Given', text: 'step22', priorKeyword: 'then'},
-        line: 14
+        line: 14,
+        column: 3,
       },
       {
         messageElements: { keyword: 'When', text: 'step32', priorKeyword: 'then'},
-        line: 18
+        line: 18,
+        column: 3,
       },
       {
         messageElements: { keyword: 'When', text: 'step54', priorKeyword: 'then'},
-        line: 24
+        line: 24,
+        column: 3,
       },
       {
         messageElements: { keyword: 'When', text: 'step42', priorKeyword: 'then'},
-        line: 28
+        line: 28,
+        column: 3,
       },
       {
         messageElements: { keyword: 'Given', text: 'step43', priorKeyword: 'then'},
-        line: 29
+        line: 29,
+        column: 3,
       },
     ]);
   });

--- a/test/rules/max-scenarios-per-file/max-scenarios-per-file.js
+++ b/test/rules/max-scenarios-per-file/max-scenarios-per-file.js
@@ -14,19 +14,19 @@ describe('Max Scenarios per File rule', function () {
   });
 
   it('detects errors for when a feature file has too many scenarios', function () {
-    return runTest('max-scenarios-per-file/TooManyScenarios.feature', { maxScenarios: 10 }, [{ messageElements: { variable: 11 }, line: 0 }])
+    return runTest('max-scenarios-per-file/TooManyScenarios.feature', { maxScenarios: 10 }, [{ messageElements: { variable: 11 }, line: 0, column: 0 }])
       .then(() => {
-        return  runTest('max-scenarios-per-file/TooManyExamples.feature', { maxScenarios: 10 }, [{ messageElements: { variable: 11 }, line: 0 }]);
+        return  runTest('max-scenarios-per-file/TooManyExamples.feature', { maxScenarios: 10 }, [{ messageElements: { variable: 11 }, line: 0, column: 0 }]);
       });
   });
 
   it('considers a scenario outline with many examples to be one scenario when "countOutlineExamples" is on', function () {
-    runTest('max-scenarios-per-file/TooManyScenarios.feature', { maxScenarios: 10, countOutlineExamples: false }, [{ messageElements: { variable: 11 }, line: 0 }]);
+    runTest('max-scenarios-per-file/TooManyScenarios.feature', { maxScenarios: 10, countOutlineExamples: false }, [{ messageElements: { variable: 11 }, line: 0, column: 0 }]);
     runTest('max-scenarios-per-file/TooManyExamples.feature', { maxScenarios: 10, countOutlineExamples: false }, []);
   });
 
   it('considers a scenario outline with many examples to be one scenario when "countOutlineExamples" is false', function () {
-    runTest('max-scenarios-per-file/TooManyScenarios.feature', { maxScenarios: 10, countOutlineExamples: false }, [{ messageElements: { variable: 11 }, line: 0 }]);
+    runTest('max-scenarios-per-file/TooManyScenarios.feature', { maxScenarios: 10, countOutlineExamples: false }, [{ messageElements: { variable: 11 }, line: 0, column: 0 }]);
     runTest('max-scenarios-per-file/TooManyExamples.feature', { maxScenarios: 10, countOutlineExamples: false }, []);
   });
 });

--- a/test/rules/name-length/name-length.js
+++ b/test/rules/name-length/name-length.js
@@ -11,22 +11,28 @@ describe('Name length rule', function() {
   it('detects errors for features, scenarios, scenario outlines and steps', function() {
     return runTest('name-length/WrongLength.feature', {}, [{
       messageElements: {element: 'Feature', length: 89},
-      line: 1
+      line: 1,
+      column: 1,
     },{
       messageElements: {element: 'Step', length: 94},
-      line: 4
+      line: 4,
+      column: 3,
     },{
       messageElements: {element: 'Scenario', length: 90},
-      line: 6
+      line: 6,
+      column: 1,
     },{
       messageElements: {element: 'Step', length: 101},
-      line: 7
+      line: 7,
+      column: 3,
     },{
       messageElements: {element: 'Scenario', length: 98},
-      line: 9
+      line: 9,
+      column: 1,
     },{
       messageElements: {element: 'Step', length: 108},
-      line: 10
+      line: 10,
+      column: 3,
     }]);
   });
 });

--- a/test/rules/new-line-at-eof/new-line-at-eof.js
+++ b/test/rules/new-line-at-eof/new-line-at-eof.js
@@ -21,9 +21,9 @@ describe('New Line at EOF Rule', function() {
       var featureStub = undefined; // not used by the rule
       var fileStub = {name: 'foo.feature', lines: []};
       var invalidConfiguration = ['on', 'k'];
-      
+
       rule.run(featureStub, fileStub, invalidConfiguration);
-      
+
       var consoleErrorArgs = console.error.args.map(function (args) { // eslint-disable-line no-console
         return args[0];
       });
@@ -35,24 +35,26 @@ describe('New Line at EOF Rule', function() {
   });
 
   it('doesn\'t raise errors when the rule is configured to "yes" and there is a new line at EOF', function() {
-    runTestRequireNewLine('new-line-at-eof/NewLineAtEOF.feature', 'yes', []);
+    return runTestRequireNewLine('new-line-at-eof/NewLineAtEOF.feature', 'yes', []);
   });
 
   it('doesn\'t raise errors when the rule is configured to "no" and there is no new line at EOF', function() {
-    runTestDissallowNewLine('new-line-at-eof/NoNewLineAtEOF.feature', 'no', []);
+    return runTestDissallowNewLine('new-line-at-eof/NoNewLineAtEOF.feature', 'no', []);
   });
 
   it('raises an error when the rule is configured to "yes" and there is no new line at EOF', function() {
-    runTestRequireNewLine('new-line-at-eof/NoNewLineAtEOF.feature', 'yes', [{
+    return runTestRequireNewLine('new-line-at-eof/NoNewLineAtEOF.feature', 'yes', [{
       messageElements: {},
-      line: 5
+      line: 5,
+      column: 0
     }]);
   });
 
   it('doesn\'t raise errors when the rule is configured to "no" and there is a new line at EOF', function() {
-    runTestDissallowNewLine('new-line-at-eof/NewLineAtEOF.feature', 'no', [{
+    return runTestDissallowNewLine('new-line-at-eof/NewLineAtEOF.feature', 'no', [{
       messageElements: {},
-      line: 6
+      line: 6,
+      column: 0
     }]);
   });
 });

--- a/test/rules/no-background-only-scenario/no-background-only-scenario.js
+++ b/test/rules/no-background-only-scenario/no-background-only-scenario.js
@@ -15,6 +15,7 @@ describe('No empty Backgrounds Rule', function() {
   it('detects errors when there are violations with Scenario', function() {
     return runTest('no-background-only-scenario/ViolationsScenario.feature', {}, [ {
       line: 4,
+      column: 1,
       messageElements: {}
     }]);
   });
@@ -22,6 +23,7 @@ describe('No empty Backgrounds Rule', function() {
   it('detects errors when there are violations with Scenario Outline', function() {
     return runTest('no-background-only-scenario/ViolationsOutline.feature', {}, [ {
       line: 4,
+      column: 1,
       messageElements: {}
     }]);
   });

--- a/test/rules/no-dupe-feature-names/no-dupe-feature-names.js
+++ b/test/rules/no-dupe-feature-names/no-dupe-feature-names.js
@@ -14,6 +14,7 @@ describe('No Duplicate Feature Names Rule', function() {
         return runTest('no-dupe-feature-names/DuplicateNameFeature2.feature', {}, [
           {
             line: 3,
+            column: 1,
             messageElements: {
               location: 'test/rules/no-dupe-feature-names/DuplicateNameFeature1.feature'
             }
@@ -24,6 +25,7 @@ describe('No Duplicate Feature Names Rule', function() {
         return runTest('no-dupe-feature-names/DuplicateNameFeature3.feature', {}, [
           {
             line: 1,
+            column: 1,
             messageElements: {
               location: 'test/rules/no-dupe-feature-names/DuplicateNameFeature1.feature, test/rules/no-dupe-feature-names/DuplicateNameFeature2.feature'
             }

--- a/test/rules/no-dupe-scenario-names/no-dupe-scenario-names.js
+++ b/test/rules/no-dupe-scenario-names/no-dupe-scenario-names.js
@@ -18,6 +18,7 @@ describe('No Duplicate Scenario Names Rule', function() {
   it('raises errors when there duplicate Scenario and Scenario Outline names in a single file', function() {
     return runTest('no-dupe-scenario-names/DublicateScenarioNames.feature', {}, [{
       line: 9,
+      column: 1,
       messageElements: {location: 'test/rules/no-dupe-scenario-names/DublicateScenarioNames.feature:6'}
     }]);
   });
@@ -28,12 +29,14 @@ describe('No Duplicate Scenario Names Rule', function() {
         return runTest('no-dupe-scenario-names/DublicateScenarioNamesAcrossFiles2.feature', {}, [
           {
             line: 6,
+            column: 1,
             messageElements: {
               location: 'test/rules/no-dupe-scenario-names/DublicateScenarioNamesAcrossFiles1.feature:6'
             }
           },
           {
             line: 9,
+            column: 1,
             messageElements: {
               location: 'test/rules/no-dupe-scenario-names/DublicateScenarioNamesAcrossFiles1.feature:9'
             }
@@ -41,7 +44,7 @@ describe('No Duplicate Scenario Names Rule', function() {
         ]);
       });
   });
-  
+
   it('doesn\'t raise errors when there are duplicate scenario names in different files', function() {
     return runTest('no-dupe-scenario-names/DublicateScenarioNamesAcrossFiles1.feature', 'in-feature', [])
       .then(() => {

--- a/test/rules/no-duplicate-tags/no-duplicate-tags.js
+++ b/test/rules/no-duplicate-tags/no-duplicate-tags.js
@@ -10,19 +10,23 @@ describe('No Duplicate Tags Rule', function() {
   it('detects errors for features, scenarios, and scenario outlines', function() {
     return runTest('no-duplicate-tags/Violations.feature', {}, [{
       messageElements: {tags: '@featuretag'},
-      line: 1
+      line: 1,
+      column: 13,
     },
     {
       messageElements: {tags: '@scenariotag'},
-      line: 7
+      line: 7,
+      column: 14,
     },
     {
       messageElements: {tags: '@scenariooutlinetag'},
-      line: 11
+      line: 11,
+      column: 21,
     },
     {
       messageElements: {tags: '@examplestag'},
-      line: 14
+      line: 14,
+      column: 14,
     }]);
   });
 });

--- a/test/rules/no-empty-background/no-empty-background.js
+++ b/test/rules/no-empty-background/no-empty-background.js
@@ -15,6 +15,7 @@ describe('No empty Backgrounds Rule', function() {
   it('detects errors for scenarios, and scenario outlines', function() {
     return runTest('no-empty-background/Violations.feature', {}, [ {
       line: 4,
+      column: 1,
       messageElements: {}
     }]);
   });

--- a/test/rules/no-empty-file/no-empty-file.js
+++ b/test/rules/no-empty-file/no-empty-file.js
@@ -9,13 +9,13 @@ describe('No Empty Files Rule', function() {
 
   it('raises an error an error for feature files that are empty', function() {
     return runTest('no-empty-file/EmptyFeature.feature', {}, [
-      { messageElements: {}, line: 1 }
+      { messageElements: {}, line: 1, column: 0 }
     ]);
   });
 
   it('raises an error an error for feature files that only contain whitespace', function() {
     return runTest('no-empty-file/OnlyWhitespace.feature', {}, [
-      { messageElements: {}, line: 1 }
+      { messageElements: {}, line: 1, column: 0 }
     ]);
   });
 });

--- a/test/rules/no-examples-in-scenarios/no-examples-in-scenarios.js
+++ b/test/rules/no-examples-in-scenarios/no-examples-in-scenarios.js
@@ -9,7 +9,8 @@ describe('No Examples in Scenarios', function() {
 
   it('detects errors when an scenario has examples', function() {
     return runTest('no-examples-in-scenarios/Violations.feature', {}, [{
-      line: 6
+      line: 6,
+      column: 1,
     }]);
   });
 });

--- a/test/rules/no-files-without-scenarios/no-files-without-scenarios.js
+++ b/test/rules/no-files-without-scenarios/no-files-without-scenarios.js
@@ -13,7 +13,7 @@ describe('No Files Without Scenarios Rule', function() {
 
   it('raises an error an error for features without scenarios and scenario outlines', function() {
     return runTest('no-files-without-scenarios/Violations.feature', {}, [
-      { messageElements: {}, line: 1 }
+      { messageElements: {}, line: 1, column: 0 }
     ]);
   });
 });

--- a/test/rules/no-homogenous-tags/no-homogenous-tags.js
+++ b/test/rules/no-homogenous-tags/no-homogenous-tags.js
@@ -9,9 +9,10 @@ describe('No Homogenous Tags Rule', function() {
   });
 
   it('detects errors for scenarios, and scenario outlines', function() {
-    return runTest('no-homogenous-tags/Violations.feature', {}, [ 
+    return runTest('no-homogenous-tags/Violations.feature', {}, [
       {
         line: 1,
+        column: 1,
         messageElements: {
           intro: 'All Scenarios on this Feature',
           tags: '@tag1, @tag2',
@@ -20,6 +21,7 @@ describe('No Homogenous Tags Rule', function() {
       },
       {
         line: 11,
+        column: 1,
         messageElements: {
           intro: 'All Examples of a Scenario Outline',
           tags: '@tag5',

--- a/test/rules/no-multiple-empty-lines/no-multiple-empty-lines.js
+++ b/test/rules/no-multiple-empty-lines/no-multiple-empty-lines.js
@@ -9,13 +9,13 @@ describe('No Multiple Empty Lines Rule', function() {
 
   it('detects errors for features, scenarios, and scenario outlines', function() {
     return runTest('no-multiple-empty-lines/Violations.feature', {}, [
-      { messageElements: {}, line: 2 },
-      { messageElements: {}, line: 6 },
-      { messageElements: {}, line: 7 },
-      { messageElements: {}, line: 8 },
-      { messageElements: {}, line: 12 },
-      { messageElements: {}, line: 17 },
-      { messageElements: {}, line: 25 },
+      { messageElements: {}, line: 2, column: 0 },
+      { messageElements: {}, line: 6, column: 0 },
+      { messageElements: {}, line: 7, column: 0 },
+      { messageElements: {}, line: 8, column: 0 },
+      { messageElements: {}, line: 12, column: 0 },
+      { messageElements: {}, line: 17, column: 0 },
+      { messageElements: {}, line: 25, column: 0 },
     ]);
   });
 });

--- a/test/rules/no-partially-commented-tag-lines/no-partially-commented-tag-lines.js
+++ b/test/rules/no-partially-commented-tag-lines/no-partially-commented-tag-lines.js
@@ -9,10 +9,10 @@ describe('No Partially Commented Tag Lines Rule', function() {
 
   it('detects errors for features, scenarios, and scenario outlines', function() {
     return runTest('no-partially-commented-tag-lines/Violations.feature', {}, [
-      { messageElements: {}, line: 1 },
-      { messageElements: {}, line: 7 },
-      { messageElements: {}, line: 12 },
-      { messageElements: {}, line: 15 },
+      { messageElements: {}, line: 1, column: 1 },
+      { messageElements: {}, line: 7, column: 1 },
+      { messageElements: {}, line: 12, column: 1 },
+      { messageElements: {}, line: 15, column: 3 },
     ]);
   });
 });

--- a/test/rules/no-restricted-patterns/no-restriced-patterns.js
+++ b/test/rules/no-restricted-patterns/no-restriced-patterns.js
@@ -26,28 +26,31 @@ describe('No Restricted Patterns Rule', function() {
         messageElements: {
           string: 'Feature with disallowed patterns',
           pattern: '^.*disallowed.*$',
-          nodeType:'Feature', 
+          nodeType:'Feature',
           property: 'name'
         },
-        line: 1
+        line: 1,
+        column: 1,
       },
       {
         messageElements: {
           pattern: '^a restricted global pattern$',
           string: 'A restricted global pattern',
-          nodeType:'Feature', 
+          nodeType:'Feature',
           property: 'description'
         },
-        line: 1
+        line: 1,
+        column: 1
       },
       {
         messageElements: {
           pattern: 'a bad description',
           string: 'A bad description',
-          nodeType:'Feature', 
+          nodeType:'Feature',
           property: 'description'
         },
-        line: 1
+        line: 1,
+        column: 1
       }
     ]);
   });
@@ -68,28 +71,31 @@ describe('No Restricted Patterns Rule', function() {
         messageElements: {
           pattern: 'a bad description',
           string: 'A bad description',
-          nodeType:'Background', 
+          nodeType:'Background',
           property: 'description'
         },
-        line: 4
+        line: 4,
+        column: 1,
       },
       {
         messageElements: {
           string: 'disallowed background step',
           pattern: '^.*disallowed.*$',
-          nodeType:'Step', 
+          nodeType:'Step',
           property: 'text'
         },
-        line: 6
+        line: 6,
+        column: 3,
       },
       {
         messageElements: {
           pattern: '^a restricted global pattern$',
           string: 'a restricted global pattern',
-          nodeType:'Step', 
+          nodeType:'Step',
           property: 'text'
         },
-        line: 7
+        line: 7,
+        column: 3,
       }
     ]);
   });
@@ -110,37 +116,41 @@ describe('No Restricted Patterns Rule', function() {
         messageElements: {
           pattern: 'a bad description',
           string: 'A bad description',
-          nodeType:'Scenario', 
+          nodeType:'Scenario',
           property: 'description'
         },
-        line: 4
+        line: 4,
+        column: 1,
       },
       {
         messageElements: {
           string: 'Disallowed exact and partial matching',
           pattern: '^.*disallowed.*$',
-          nodeType:'Scenario', 
+          nodeType:'Scenario',
           property: 'name'
         },
-        line: 4
+        line: 4,
+        column: 1,
       },
       {
         messageElements: {
           string: 'disallowed scenario step',
           pattern: '^.*disallowed.*$',
-          nodeType:'Step', 
+          nodeType:'Step',
           property: 'text'
         },
-        line: 6
+        line: 6,
+        column: 3,
       },
       {
         messageElements: {
           pattern: '^a restricted global pattern$',
           string: 'a restricted global pattern',
-          nodeType:'Step', 
+          nodeType:'Step',
           property: 'text'
         },
-        line: 7
+        line: 7,
+        column: 3,
       }
     ]);
   });
@@ -161,37 +171,41 @@ describe('No Restricted Patterns Rule', function() {
         messageElements: {
           pattern: 'a bad description',
           string: 'A bad description',
-          nodeType:'Scenario Outline', 
+          nodeType:'Scenario Outline',
           property: 'description'
         },
-        line: 4
+        line: 4,
+        column: 1
       },
       {
         messageElements: {
           string: 'Disallowed exact and partial matching',
           pattern: '^.*disallowed.*$',
-          nodeType:'Scenario Outline', 
+          nodeType:'Scenario Outline',
           property: 'name'
         },
-        line: 4
+        line: 4,
+        column: 1
       },
       {
         messageElements: {
           string: 'disallowed scenario outline step',
           pattern: '^.*disallowed.*$',
-          nodeType:'Step', 
+          nodeType:'Step',
           property: 'text'
         },
-        line: 6
+        line: 6,
+        column: 3
       },
       {
         messageElements: {
           pattern: '^a restricted global pattern$',
           string: 'a restricted global pattern',
-          nodeType:'Step', 
+          nodeType:'Step',
           property: 'text'
         },
-        line: 7
+        line: 7,
+        column: 3
       }
     ]);
   });

--- a/test/rules/no-restricted-tags/no-restricted-tags.js
+++ b/test/rules/no-restricted-tags/no-restricted-tags.js
@@ -16,43 +16,53 @@ describe('No Restricted Tags Rule', function() {
       'patterns': ['^@anotherBadTag$']
     }, [{
       messageElements: {tag: '@badTag', nodeType:'Feature'},
-      line: 1
+      line: 1,
+      column: 13,
     },
     {
       messageElements: {tag: '@anotherBadTag', nodeType:'Feature'},
-      line: 1
+      line: 1,
+      column: 21,
     },
     {
       messageElements: {tag: '@badTag', nodeType:'Scenario'},
-      line: 7
+      line: 7,
+      column: 14,
     },
     {
       messageElements: {tag: '@anotherBadTag', nodeType:'Scenario'},
-      line: 7
+      line: 7,
+      column: 22,
     },
     {
       messageElements: {tag: '@badTag', nodeType:'Scenario Outline'},
-      line: 11
+      line: 11,
+      column: 14,
     },
     {
       messageElements: {tag: '@anotherBadTag', nodeType:'Scenario Outline'},
-      line: 11
+      line: 11,
+      column: 22,
     },
     {
       messageElements: {tag: '@badTag', nodeType:'Examples'},
-      line: 14
+      line: 14,
+      column: 14,
     },
     {
       messageElements: {tag: '@anotherBadTag', nodeType:'Examples'},
-      line: 14
+      line: 14,
+      column: 22,
     },
     {
       messageElements: {tag: '@badTag', nodeType:'Examples'},
-      line: 19
+      line: 19,
+      column: 14,
     },
     {
       messageElements: {tag: '@anotherBadTag', nodeType:'Examples'},
-      line: 19
+      line: 19,
+      column: 22,
     }]);
   });
 });

--- a/test/rules/no-scenario-outlines-without-examples/no-scenario-outlines-without-examples.js
+++ b/test/rules/no-scenario-outlines-without-examples/no-scenario-outlines-without-examples.js
@@ -9,20 +9,20 @@ describe('No scenario outlines without examples rule', function() {
   });
 
   it('detects errors for scenario outlines that are missing the "Examples" keyword completely', function() {
-    return runTest('no-scenario-outlines-without-examples/ViolationsNoExamples.feature', {}, [ 
-      {line: 3}
+    return runTest('no-scenario-outlines-without-examples/ViolationsNoExamples.feature', {}, [
+      {line: 3,column: 1}
     ]);
   });
 
   it('detects errors for scenario outlines that have empty "Examples"', function() {
-    return runTest('no-scenario-outlines-without-examples/ViolationsEmptyExamples.feature', {}, [ 
-      {line: 3}
+    return runTest('no-scenario-outlines-without-examples/ViolationsEmptyExamples.feature', {}, [
+      {line: 3,column: 1}
     ]);
   });
 
   it('detects errors for scenario outlines that define variable names but don\'t have any values to iterate over', function() {
-    return runTest('no-scenario-outlines-without-examples/ViolationsNoExamplesBody.feature', {}, [ 
-      {line: 3}
+    return runTest('no-scenario-outlines-without-examples/ViolationsNoExamplesBody.feature', {}, [
+      {line: 3,column: 1}
     ]);
   });
 });

--- a/test/rules/no-superfluous-tags/no-superfluous-tags.js
+++ b/test/rules/no-superfluous-tags/no-superfluous-tags.js
@@ -12,6 +12,7 @@ describe('No Superfluous Tags Rule', function() {
     return runTest('no-superfluous-tags/Violations.feature', {}, [
       {
         line: 7,
+        column: 1,
         messageElements: {
           childType: 'Scenario',
           parentType: 'Feature',
@@ -20,6 +21,7 @@ describe('No Superfluous Tags Rule', function() {
       },
       {
         line: 11,
+        column: 1,
         messageElements: {
           childType: 'Scenario Outline',
           parentType: 'Feature',
@@ -28,6 +30,7 @@ describe('No Superfluous Tags Rule', function() {
       },
       {
         line: 11,
+        column: 18,
         messageElements: {
           childType: 'Scenario Outline',
           parentType: 'Feature',
@@ -36,6 +39,7 @@ describe('No Superfluous Tags Rule', function() {
       },
       {
         line: 14,
+        column: 1,
         messageElements: {
           childType: 'Examples',
           parentType: 'Feature',
@@ -44,6 +48,7 @@ describe('No Superfluous Tags Rule', function() {
       },
       {
         line: 14,
+        column: 1,
         messageElements: {
           childType: 'Examples',
           parentType: 'Scenario Outline',
@@ -52,6 +57,7 @@ describe('No Superfluous Tags Rule', function() {
       },
       {
         line: 14,
+        column: 32,
         messageElements: {
           childType: 'Examples',
           parentType: 'Scenario Outline',

--- a/test/rules/no-trailing-spaces/no-trailing-space.js
+++ b/test/rules/no-trailing-spaces/no-trailing-space.js
@@ -11,15 +11,18 @@ describe('No Trailing Spaces Rule', function() {
     return runTest('no-trailing-spaces/TrailingSpaces.feature', {}, [
       {
         messageElements: {},
-        line: 1
+        line: 1,
+        column: 0
       },
       {
         messageElements: {},
-        line: 3
+        line: 3,
+        column: 0
       },
       {
         messageElements: {},
-        line: 4
+        line: 4,
+        column: 0
       }
     ]);
   });
@@ -28,7 +31,8 @@ describe('No Trailing Spaces Rule', function() {
     return runTest('no-trailing-spaces/TrailingTabs.feature', {}, [
       {
         messageElements: {},
-        line: 4
+        line: 4,
+        column: 0
       }
     ]);
   });

--- a/test/rules/no-unnamed-features/no-unnamed-features.js
+++ b/test/rules/no-unnamed-features/no-unnamed-features.js
@@ -11,7 +11,8 @@ describe('No Unnamed Features Rule', function() {
     return runTest('no-unnamed-features/EmptyFeature.feature', {}, [
       {
         messageElements: {},
-        line: 0
+        line: 0,
+        column: 0,
       }
     ]);
   });
@@ -20,7 +21,8 @@ describe('No Unnamed Features Rule', function() {
     return runTest('no-unnamed-features/UnnamedFeature.feature', {}, [
       {
         messageElements: {},
-        line: 3
+        line: 3,
+        column: 1,
       }
     ]);
   });

--- a/test/rules/no-unnamed-scenarios/no-unnamed-scenarios.js
+++ b/test/rules/no-unnamed-scenarios/no-unnamed-scenarios.js
@@ -6,7 +6,7 @@ describe('No Unnamed Scenarios Rule', function() {
   it('doesn\'t raise errors when there are no violations', function() {
     return runTest('no-unnamed-scenarios/NoViolations.feature', {}, []);
   });
-  
+
   it('doesn\'t raise errors for a feature with no scenarios', function() {
     return runTest('no-unnamed-scenarios/FeatureWithNoScenarios.feature', {}, []);
   });
@@ -15,11 +15,13 @@ describe('No Unnamed Scenarios Rule', function() {
     return runTest('no-unnamed-scenarios/Violations.feature', {}, [
       {
         messageElements: {},
-        line: 3
+        line: 3,
+        column: 1,
       },
       {
         messageElements: {},
-        line: 6
+        line: 6,
+        column: 1,
       }
     ]);
   });

--- a/test/rules/no-unused-variables/no-unused-variables.js
+++ b/test/rules/no-unused-variables/no-unused-variables.js
@@ -14,22 +14,27 @@ describe('No Unused Variables Rule', function() {
     return runTest('no-unused-variables/UnusedStepVariables.feature', {}, [
       {
         line: 5,
+        column: 20,
         messageElements: {variable: 'b'}
       },
       {
         line: 12,
+        column: 20,
         messageElements: {variable: 'b'}
       },
       {
         line: 18,
+        column: 107,
         messageElements: {variable: 'b'}
       },
       {
         line: 30,
+        column: 7,
         messageElements: {variable: 'b'}
       },
       {
-        line: 41,
+        line: 42,
+        column: 0,
         messageElements: {variable: 'b'}
       }
     ]);
@@ -42,26 +47,32 @@ describe('No Unused Variables Rule', function() {
     return runTest('no-unused-variables/UnusedExampleVariables.feature', {}, [
       {
         line: 7,
+        column: 11,
         messageElements: {variable: 'b'}
-      }, 
+      },
       {
         line: 14,
+        column: 11,
         messageElements: {variable: 'b'}
       },
       {
         line: 26,
+        column: 7,
         messageElements: {variable: 'b'}
       },
       {
         line: 35,
+        column: 11,
         messageElements: {variable: 'b'}
       },
       {
         line: 49,
+        column: 7,
         messageElements: {variable: 'b'}
       },
       {
         line: 61,
+        column: 11,
         messageElements: {variable: 'b'}
       }
     ]);

--- a/test/rules/one-space-between-tags/one-space-between-tags.js
+++ b/test/rules/one-space-between-tags/one-space-between-tags.js
@@ -12,22 +12,27 @@ describe('One Space Between Tags Rule', function() {
     return runTest('one-space-between-tags/Violations.feature', {}, [
       {
         line: 1,
+        column: 1,
         messageElements: {left: '@featuretag1', right: '@featuretag2'}
-      }, 
+      },
       {
         line: 9,
+        column: 1,
         messageElements: {left: '@scenariotag3', right: '@scenariotag4'}
-      }, 
+      },
       {
         line: 9,
+        column: 17,
         messageElements: {left: '@scenariotag4', right: '@scenariotag5'}
-      }, 
+      },
       {
         line: 13,
+        column: 1,
         messageElements: {left: '@scenariotag5', right: '@scenariotag6'}
-      }, 
+      },
       {
         line: 16,
+        column: 1,
         messageElements: {left: '@examplestag1', right: '@examplestag2'}
       }
     ]);

--- a/test/rules/required-tags/required-tags.js
+++ b/test/rules/required-tags/required-tags.js
@@ -13,16 +13,20 @@ describe('Required Tags Rule', function() {
       'tags': ['@requiredscenariotag', '@requiredScenarioTag', '@required-scenario-tag-\\d+']
     }, [{
       messageElements: {tags: '@requiredScenarioTag', nodeType: 'Scenario'},
-      line: 8
+      line: 8,
+      column: 1,
     }, {
       messageElements: {tags: '@requiredScenarioTag', nodeType: 'Scenario Outline'},
-      line: 13
+      line: 13,
+      column: 1,
     }, {
       messageElements: {tags: '@required-scenario-tag-\\d+', nodeType: 'Scenario'},
-      line: 8
+      line: 8,
+      column: 1,
     }, {
       messageElements: {tags: '@required-scenario-tag-\\d+', nodeType: 'Scenario Outline'},
-      line: 13
+      line: 13,
+      column: 1,
     }]);
   });
   it('detects errors for scenarios and scenario outlines that have no tag', () => {
@@ -31,10 +35,12 @@ describe('Required Tags Rule', function() {
       'ignoreUntagged': false
     }, [{
       messageElements: {tags: '@requiredscenariotag', nodeType: 'Scenario'},
-      line: 20
+      line: 20,
+      column: 1,
     }, {
       messageElements: {tags: '@requiredscenariotag', nodeType: 'Scenario Outline'},
-      line: 23
+      line: 23,
+      column: 1,
     }]);
   });
 });

--- a/test/rules/rule-test-base.js
+++ b/test/rules/rule-test-base.js
@@ -9,7 +9,8 @@ function createRuleTest(rule, messageTemplate) {
       return {
         rule: rule.name,
         message: _.template(messageTemplate)(error.messageElements),
-        line: error.line
+        line: error.line,
+        column: error.column,
       };
     });
     return linter.readAndParseFile('test/rules/' + featureFile, 'utf8')

--- a/test/rules/scenario-size/scenario-size.js
+++ b/test/rules/scenario-size/scenario-size.js
@@ -12,6 +12,7 @@ describe('Scenario size Rule', function() {
       'Scenario': 3
     }}, [{
       line: 3,
+      column: 1,
       messageElements: {
         type: 'Background',
         actual: 5,
@@ -20,14 +21,16 @@ describe('Scenario size Rule', function() {
     },
     {
       line: 10,
+      column: 1,
       messageElements: {
-        type: 'Scenario', 
+        type: 'Scenario',
         actual: 5,
         expected: 3
       }
     },
     {
       line: 17,
+      column: 1,
       messageElements: {
         type: 'Scenario Outline',
         actual: 5,

--- a/test/rules/use-and/use-and.js
+++ b/test/rules/use-and/use-and.js
@@ -1,6 +1,6 @@
 var ruleTestBase = require('../rule-test-base');
 var rule = require('../../../dist/rules/use-and.js');
-var runTest = ruleTestBase.createRuleTest(rule, 
+var runTest = ruleTestBase.createRuleTest(rule,
   'Step "<%= keyword %><%= text %>" should use And instead of <%= keyword %>');
 
 describe('Use And Rule', function() {
@@ -12,39 +12,48 @@ describe('Use And Rule', function() {
     return runTest('use-and/Violations.feature', {}, [
       {
         messageElements: { keyword: 'Given ', text: 'step5'},
-        line: 5
+        line: 5,
+        column: 3,
       },
       {
         messageElements: { keyword: 'When ', text: 'step8'},
-        line: 8
+        line: 8,
+        column: 3,
       },
       {
         messageElements: { keyword: 'Then ', text: 'step11'},
-        line: 11
+        line: 11,
+        column: 3,
       },
       {
         messageElements: { keyword: 'Given ', text: 'step16'},
-        line: 16
+        line: 16,
+        column: 3,
       },
       {
         messageElements: { keyword: 'When ', text: 'step19'},
-        line: 19
+        line: 19,
+        column: 3,
       },
       {
         messageElements: { keyword: 'Then ', text: 'step22'},
-        line: 22
+        line: 22,
+        column: 3,
       },
       {
         messageElements: { keyword: 'Given ', text: 'step27'},
-        line: 27
+        line: 27,
+        column: 3
       },
       {
         messageElements: { keyword: 'When ', text: 'step30'},
-        line: 30
+        line: 30,
+        column: 3,
       },
       {
         messageElements: { keyword: 'Then ', text: 'step33'},
-        line: 33
+        line: 33,
+        column: 3,
       }
     ]);
   });

--- a/test/rulesdir/other_rules/custom-list.js
+++ b/test/rulesdir/other_rules/custom-list.js
@@ -8,7 +8,8 @@ function custom() {
     {
       message: 'Another custom-list error',
       rule   : rule,
-      line   : 109
+      line   : 109,
+      column : 27
     }
   ];
 }

--- a/test/rulesdir/other_rules/custom.js
+++ b/test/rulesdir/other_rules/custom.js
@@ -5,7 +5,8 @@ function custom() {
     {
       message: 'Another custom error',
       rule   : rule,
-      line   : 456
+      line   : 456,
+      column: 23
     }
   ];
 }

--- a/test/rulesdir/rules/custom.js
+++ b/test/rulesdir/rules/custom.js
@@ -5,7 +5,8 @@ function custom() {
     {
       message: 'Custom error',
       rule   : rule,
-      line   : 123
+      line   : 123,
+      column : 21
     }
   ];
 }

--- a/test/rulesdir/rulesdir.js
+++ b/test/rulesdir/rulesdir.js
@@ -18,21 +18,25 @@ describe('rulesdir CLI option', function() {
             errors: [
               { // This one is to make sure we don't accidentally regress and always load the default rules
                 line: 1,
+                column: 5,
                 message: 'Wrong indentation for "Feature", expected indentation level of 0, but got 4',
                 rule: 'indentation'
               },
               {
                 line: 109,
+                column: 27,
                 message: 'Another custom-list error',
                 rule: 'another-custom-list'
               },
               {
                 line: 123,
+                column: 21,
                 message: 'Custom error',
                 rule: 'custom'
               },
               {
                 line: 456,
+                column: 23,
                 message: 'Another custom error',
                 rule: 'another-custom'
               }
@@ -41,5 +45,5 @@ describe('rulesdir CLI option', function() {
           }
         ]);
       });
-  });    
+  });
 });


### PR DESCRIPTION
feat() Improve console output using stylish
 - Include column number (if is not provided column is `0`)
 - Include error constant (in conjunction with column number allows some IDEs to recognize output as a link to the failure).
feat() Fixed some tests with missing return (promise not evaluated)