### PR TITLE
Adds no-empty-lines-after-examples new rule

### DIFF
--- a/src/rules/no-empty-lines-after-examples.js
+++ b/src/rules/no-empty-lines-after-examples.js
@@ -1,0 +1,24 @@
+const gherkinUtils = require('./utils/gherkin.js');
+const rule = 'no-empty-lines-after-examples';
+
+function run(unused, file) {
+  let errors = [];
+
+  for (let i = 0; i < file.lines.length - 1; i++) {
+    const exampleKeyword = gherkinUtils.getInsitiveKeyword('examples', unused.language);
+
+    if (file.lines[i].includes(exampleKeyword) && file.lines[i + 1].trim() === '') {
+      errors.push({
+        message: 'Empty lines after Examples are not allowed',
+        rule: rule,
+        line: i + 1
+      });
+    }
+  }
+  return errors;
+}
+
+module.exports = {
+  name: rule,
+  run: run
+};

--- a/src/rules/utils/gherkin.js
+++ b/src/rules/utils/gherkin.js
@@ -30,7 +30,6 @@ function getNodeType(node, language) {
   }
   return '';
 }
- 
 
 function getLanguageInsitiveKeyword(node, language) {
   const languageMapping = Gherkin.dialects()[language];
@@ -38,8 +37,13 @@ function getLanguageInsitiveKeyword(node, language) {
   return _.findKey(languageMapping, values => values instanceof Array && values.includes(node.keyword));
 }
 
+function getInsitiveKeyword(commonKeyword, language) {
+  const languageMapping = Gherkin.dialects()[language];
+  return languageMapping[commonKeyword][0];
+}
 
 module.exports = {
   getNodeType: getNodeType,
   getLanguageInsitiveKeyword: getLanguageInsitiveKeyword,
+  getInsitiveKeyword: getInsitiveKeyword
 };

--- a/test-data-wip/.gherkin-lintrc
+++ b/test-data-wip/.gherkin-lintrc
@@ -10,6 +10,7 @@
   "new-line-at-eof": ["on", "yes"],
   "no-multiple-empty-lines": "on",
   "no-empty-file": "on",
+  "no-empty-lines-after-examples": "on",
   "no-scenario-outlines-without-examples": "on",
   "name-length": ["on", {"Feature": 50}],
   "no-restricted-tags": ["on", {"tags": ["@watch", "@wip"]}],

--- a/test-data-wip/EmptyLineAfterExamples.feature
+++ b/test-data-wip/EmptyLineAfterExamples.feature
@@ -1,0 +1,10 @@
+Feature: Test for the no-empty-lines-after-examples
+
+Scenario Outline: This is a Scenario for no-empty-lines-after-examples
+  Given I have a feature file with empty line after "<sectionName>" section
+  Then I should see no-empty-lines-after-examples error
+  Examples:
+
+    | sectionName |
+    | Examples    |
+

--- a/test/rules/no-empty-lines-after-examples/NoViolations.feature
+++ b/test/rules/no-empty-lines-after-examples/NoViolations.feature
@@ -1,0 +1,16 @@
+@featuretag
+Feature: This is a Feature
+
+Background:
+  Given I have a Background
+
+@scenariotag
+Scenario: This is a Scenario
+  Then this is a then step
+
+@scenariotag
+Scenario Outline: This is a Scenario Outline
+  Then this is a then step <foo>
+Examples:
+  | foo |
+  | bar |

--- a/test/rules/no-empty-lines-after-examples/Violations.feature
+++ b/test/rules/no-empty-lines-after-examples/Violations.feature
@@ -1,0 +1,18 @@
+@featuretag
+Feature: This is a Feature
+
+Background:
+  Given I have a Background
+
+@scenariotag
+Scenario: This is a Scenario
+  Then this is a then step
+
+@scenariotag
+Scenario Outline: This is a Scenario Outline
+  Then this is a then step <foo>
+
+Examples:
+
+  | foo |
+  | bar |

--- a/test/rules/no-empty-lines-after-examples/no-multiple-empty-lines.js
+++ b/test/rules/no-empty-lines-after-examples/no-multiple-empty-lines.js
@@ -1,0 +1,15 @@
+var ruleTestBase = require('../rule-test-base');
+var rule = require('../../../dist/rules/no-empty-lines-after-examples.js');
+var runTest = ruleTestBase.createRuleTest(rule, 'Empty lines after Examples are not allowed');
+
+describe('Empty lines after Examples are not allowed', function() {
+  it('doesn\'t raise errors when there are no violations', function() {
+    return runTest('no-empty-lines-after-examples/NoViolations.feature', {}, []);
+  });
+
+  it('detects errors for features, scenarios, and scenario outlines', function() {
+    return runTest('no-empty-lines-after-examples/Violations.feature', {}, [
+      { messageElements: {}, line: 15 }
+    ]);
+  });
+});


### PR DESCRIPTION
Add a new rule which raises an error if there is at least one empty line after the 'Examples' line.
