### PR TITLE
Feature/support dialect

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,3 +5,5 @@ npm-debug.log
 .DS_Store
 .nyc_output
 coverage
+.devcontainer
+.vscode

--- a/README.md
+++ b/README.md
@@ -298,3 +298,20 @@ gherkin-lint --rulesdir "/path/to/my/rulesdir" --rulesdir "from/cwd/rulesdir"
 
 Paths can either be absolute or relative to the current working directory.
 Have a look at the `src/rules/` directory for examples; The `no-empty-file` rule is a good example to start with.
+
+## Feature Files default language
+"English" is the default supported feature files language.
+You can overwrite it by using the option `-l` or `--language` followed by the
+[supported regional code](https://cucumber.io/docs/gherkin/languages/).  
+
+Example:  
+```
+`gherkin-lint -l 'fr'` (for french as default language).
+```
+
+Another option is to add the language as comment for each your feature file.  
+Example:  
+```gherkin
+# language:en
+Feature: This is a feature in English
+```

--- a/README.md
+++ b/README.md
@@ -306,7 +306,7 @@ You can overwrite it by using the option `-l` or `--language` followed by the
 
 Example:  
 ```
-`gherkin-lint -l 'fr'` (for french as default language).
+gherkin-lint -l 'fr'  (for french as default language)
 ```
 
 Another option is to add the language as comment for each your feature file.  

--- a/src/linter.js
+++ b/src/linter.js
@@ -4,7 +4,7 @@ const fs = require('fs');
 const rules = require('./rules.js');
 const logger = require('./logger.js');
 
-function readAndParseFile(filePath) {
+function readAndParseFile(filePath, unused, language = undefined) {
   let feature ='';
   let parsingErrors = [];
   let fileContent = [];
@@ -14,6 +14,8 @@ function readAndParseFile(filePath) {
       includeGherkinDocument: true,
       includePickles: false,
       includeSource: true,
+      defaultDialect: language,
+
     };
 
     const stream = Gherkin.fromPaths([filePath], options);
@@ -56,13 +58,13 @@ function readAndParseFile(filePath) {
 }
 
 
-function lint(files, configuration, additionalRulesDirs) {
+function lint(files, configuration, additionalRulesDirs, language = 'en') {
   let results = [];
 
   return Promise.all(files.map((f) => {
     let perFileErrors = [];
 
-    return readAndParseFile(f)
+    return readAndParseFile(f, null, language)
       .then(
         // Handle Promise.resolve 
         ({feature, file}) => {

--- a/src/main.js
+++ b/src/main.js
@@ -21,12 +21,13 @@ program
   .option('-i, --ignore <...>', 'comma seperated list of files/glob patterns that the linter should ignore, overrides ' + featureFinder.defaultIgnoreFileName + ' file', list)
   .option('-c, --config [config]', 'configuration file, defaults to ' + configParser.defaultConfigFileName)
   .option('-r, --rulesdir <...>', 'additional rule directories', collect, [])
+  .option('-l, --language [language]', 'feature file language. Defaults to English')
   .parse(process.argv);
 
 const additionalRulesDirs = program.rulesdir;
 const files = featureFinder.getFeatureFiles(program.args, program.ignore);
 const config = configParser.getConfiguration(program.config, additionalRulesDirs);
-linter.lint(files, config, additionalRulesDirs)
+linter.lint(files, config, additionalRulesDirs, program.language)
   .then((results) => {
     printResults(results, program.format);
     process.exit(getExitCode(results));

--- a/test-data-wip/InvalidLanguage.feature
+++ b/test-data-wip/InvalidLanguage.feature
@@ -1,0 +1,7 @@
+# language:en
+Fonctionnalité: Test for detecting invalid language (french instead of english)
+
+Scénario: Se déconnecter de l'application
+  Étant donné que Ulrick est connecté à son compte
+  Quand Ulrick se déconnecte de son compte
+  Alors Ulrick voit la page de connection

--- a/test/linter/FeatureInFrenchNoViolations.feature
+++ b/test/linter/FeatureInFrenchNoViolations.feature
@@ -1,0 +1,6 @@
+Fonctionnalité: Se déconnecter de l'application 
+
+ Scénario: Se déconnecter de l'application 
+  Étant donné que Ulrick est connecté à son compte
+  Quand Ulrick se déconnecte de son compte 
+  Alors Ulrick voit la page de connection

--- a/test/linter/FeatureInFrenchNoViolations.feature
+++ b/test/linter/FeatureInFrenchNoViolations.feature
@@ -1,4 +1,4 @@
-Fonctionnalité: Se déconnecter de l'application 
+Fonctionnalité: This is a feature in french 
 
  Scénario: Se déconnecter de l'application 
   Étant donné que Ulrick est connecté à son compte

--- a/test/linter/linter.js
+++ b/test/linter/linter.js
@@ -2,8 +2,8 @@ var assert = require('chai').assert;
 var linter = require('../../dist/linter.js');
 
 
-function linterTest(feature, expected) {
-  return linter.lint([feature], {})
+function linterTest(feature, expected, language = 'en') {
+  return linter.lint([feature], {}, '', language)
     .then((actual) => {
       assert.lengthOf(actual, 1);
       assert.deepEqual(actual[0].errors, expected);
@@ -96,5 +96,46 @@ describe('Linter', function() {
     let feature = 'test/linter/NoViolations.feature';
     let expected = [];
     return linterTest(feature, expected);   
+  });
+
+  it('correctly parses files that have the correct Gherkin format in French', function() {
+    let feature = 'test/linter/FeatureInFrenchNoViolations.feature';
+    let expected = [];
+    return linterTest(feature, expected, 'fr');   
+  });
+
+  it('detect when language is not in French', function() {
+    let feature = 'test/linter/NoViolations.feature';
+    let expected = [
+      {
+        'line': '1',
+        'message': 'Multiple "Feature" definitions in the same file are disallowed',
+        'rule': 'one-feature-per-file'
+      },
+      {
+        'line': '3',
+        'message': 'Multiple "Background" definitions in the same file are disallowed',
+        'rule': 'up-to-one-background-per-file'
+      },
+      {
+        'line': '4',
+        // eslint-disable-next-line
+        'message': "(4:3): expected: #EOF, #Language, #TagLine, #FeatureLine, #Comment, #Empty, got 'Given I have a Feature file'",
+        'rule': 'unexpected-error'
+      },
+      {
+        'line': '6',
+        // eslint-disable-next-line
+        'message': "(6:1): expected: #EOF, #Language, #TagLine, #FeatureLine, #Comment, #Empty, got 'Scenario: This is a Scenario'",
+        'rule': 'unexpected-error'
+      },
+      {
+        'line': '7',
+        // eslint-disable-next-line
+        'message': "(7:3): expected: #EOF, #Language, #TagLine, #FeatureLine, #Comment, #Empty, got 'Then this is a step'",
+        'rule': 'unexpected-error'
+      }
+    ];
+    return linterTest(feature, expected, 'fr');   
   });
 });


### PR DESCRIPTION
Add support for another language than English.

Example for french language:

```shell
gherkin-lint -l 'fr'
```