### PR TITLE
Adding option to Required Tags 

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,5 @@
 # Gherkin lint
+
 [![Travis](https://travis-ci.com/vsiakka/gherkin-lint.svg?branch=master)](https://travis-ci.com/github/vsiakka/gherkin-lint/branches)
 [![Coverage Status](https://coveralls.io/repos/github/vsiakka/gherkin-lint/badge.svg?branch=master)](https://coveralls.io/github/vsiakka/gherkin-lint?branch=master)
 [![David](https://img.shields.io/david/vsiakka/gherkin-lint.svg?maxAge=2592000)](https://david-dm.org/vsiakka/gherkin-lint)
@@ -8,71 +9,76 @@
 Uses [Gherkin](https://github.com/cucumber/gherkin-javascript) to parse feature files and runs linting against the default rules, and the optional rules you specified in your `.gherkin-lintrc` file.
 
 ## Installation
+
 ```
 npm install gherkin-lint
 ```
 
 ## Demo
+
 To see the output for all the errors that the linter can detect run:
+
 ```
 git clone https://github.com/vsiakka/gherkin-lint.git
 npm run demo
 ```
+
 Or check this:
 ![console](https://i.imgur.com/Qfp1FQR.png)
 
-
 ## Available rules
 
-
-| Name                                        | Functionality                                                                            |
-|---------------------------------------------|------------------------------------------------------------------------------------------|
-| `no-tags-on-backgrounds` *                  | Disallows tags on Background                                                             |
-| `one-feature-per-file` *                    | Disallows multiple Feature definitions in the same file                                  |
-| `up-to-one-background-per-file` *           | Disallows multiple Background definition in the same file                                |
-| `no-multiline-steps` *                      | Disallows mutiline Steps                                                                 || &nbsp;                                      |                                                                                          |
-| [`allowed-tags`](#allowed-tags)             | Just the listed tags are allowed                                                         |
-| [`file-name`](#file-name)                   | Restrict feature file names to a commmon style                                           |
-| [`indentation`](#indentation)               | Allows the user to specify indentation rules                                             |
-| [`max-scenarios-per-file`](#max-scenarios-per-file)| Allows the user to specify the max number of scenarios per feature file           |
-| [`name-length`](#name-length)               | Allows restricting length of Feature/Scenario/Step names                                 |
-| [`new-line-at-eof`](#new-line-at-eof)       | Disallows/enforces new line at EOF                                                       |
-| `no-background-only-scenario`               | Disallows background when there is just one scenario                                     |
-| `no-dupe-feature-names`                     | Disallows duplicate Feature names                                                        |
-| [`no-dupe-scenario-names`](#no-dupe-scenario-names)| Disallows duplicate Scenario names                                                |
-| `no-duplicate-tags`                         | Disallows duplicate tags on the same Feature or Scenario                                 |
-| `no-empty-background`                       | Disallows features with backgrounds without steps                                        |
-| `no-empty-file`                             | Disallows empty feature files                                                            |
-| `no-examples-in-scenarios`                  | Disallow the use of "Examples" in Scenarios, only allowed in Scenario Outlines           |
-| `no-files-without-scenarios`                | Disallows files with no scenarios                                                        |
-| `no-homogenous-tags`                        | Disallows tags present on every Scenario in a Feature, rather than on the Feature itself |
-| `no-multiple-empty-lines`                   | Disallows multiple empty lines                                                           |
-| `no-partially-commented-tag-lines`          | Disallows partially commented tag lines                                                  |
-| [`no-restricted-patterns`](#no-restricted-patterns)        | A list of patterns to disallow globally, or specifically in features, backgrounds, scenarios, or scenario outlines                                 |
-| [`no-restricted-tags`](#no-restricted-tags) | Disallow use of particular @tags                                                         |
-| `no-scenario-outlines-without-examples`     | Disallows scenario outlines without examples                                             |
-| `no-superfluous-tags`                       | Disallows tags present on a Feature and a Scenario in that Feature                       |
-| `no-trailing-spaces`                        | Disallows trailing spaces                                                                |
-| `no-unnamed-features`                       | Disallows empty Feature name                                                             |
-| `no-unnamed-scenarios`                      | Disallows empty Scenario name                                                            |
-| `no-unused-variables`                       | Disallows unused variables in scenario outlines                                          |
-| `one-space-between-tags`                    | Tags on the same line must be separated by a single space                                |
-| [`required-tags`](#required-tags)           | Require tags/patterns of tags on Scenarios                                               |
-| [`scenario-size`](#scenario-size)           | Allows restricting the maximum number of steps in a scenario, scenario outline and background |
-| `use-and`                                   | Disallows repeated step names requiring use of And instead                               |
-| `keywords-in-logical-order`                 | Requires that Given, When and Then appear in logical sequence                            |
+| Name                                                | Functionality                                                                                                      |
+| --------------------------------------------------- | ------------------------------------------------------------------------------------------------------------------ | --- | ------ | --- |
+| `no-tags-on-backgrounds` \*                         | Disallows tags on Background                                                                                       |
+| `one-feature-per-file` \*                           | Disallows multiple Feature definitions in the same file                                                            |
+| `up-to-one-background-per-file` \*                  | Disallows multiple Background definition in the same file                                                          |
+| `no-multiline-steps` \*                             | Disallows mutiline Steps                                                                                           |     | &nbsp; |     |
+| [`allowed-tags`](#allowed-tags)                     | Just the listed tags are allowed                                                                                   |
+| [`file-name`](#file-name)                           | Restrict feature file names to a commmon style                                                                     |
+| [`indentation`](#indentation)                       | Allows the user to specify indentation rules                                                                       |
+| [`max-scenarios-per-file`](#max-scenarios-per-file) | Allows the user to specify the max number of scenarios per feature file                                            |
+| [`name-length`](#name-length)                       | Allows restricting length of Feature/Scenario/Step names                                                           |
+| [`new-line-at-eof`](#new-line-at-eof)               | Disallows/enforces new line at EOF                                                                                 |
+| `no-background-only-scenario`                       | Disallows background when there is just one scenario                                                               |
+| `no-dupe-feature-names`                             | Disallows duplicate Feature names                                                                                  |
+| [`no-dupe-scenario-names`](#no-dupe-scenario-names) | Disallows duplicate Scenario names                                                                                 |
+| `no-duplicate-tags`                                 | Disallows duplicate tags on the same Feature or Scenario                                                           |
+| `no-empty-background`                               | Disallows features with backgrounds without steps                                                                  |
+| `no-empty-file`                                     | Disallows empty feature files                                                                                      |
+| `no-examples-in-scenarios`                          | Disallow the use of "Examples" in Scenarios, only allowed in Scenario Outlines                                     |
+| `no-files-without-scenarios`                        | Disallows files with no scenarios                                                                                  |
+| `no-homogenous-tags`                                | Disallows tags present on every Scenario in a Feature, rather than on the Feature itself                           |
+| `no-multiple-empty-lines`                           | Disallows multiple empty lines                                                                                     |
+| `no-partially-commented-tag-lines`                  | Disallows partially commented tag lines                                                                            |
+| [`no-restricted-patterns`](#no-restricted-patterns) | A list of patterns to disallow globally, or specifically in features, backgrounds, scenarios, or scenario outlines |
+| [`no-restricted-tags`](#no-restricted-tags)         | Disallow use of particular @tags                                                                                   |
+| `no-scenario-outlines-without-examples`             | Disallows scenario outlines without examples                                                                       |
+| `no-superfluous-tags`                               | Disallows tags present on a Feature and a Scenario in that Feature                                                 |
+| `no-trailing-spaces`                                | Disallows trailing spaces                                                                                          |
+| `no-unnamed-features`                               | Disallows empty Feature name                                                                                       |
+| `no-unnamed-scenarios`                              | Disallows empty Scenario name                                                                                      |
+| `no-unused-variables`                               | Disallows unused variables in scenario outlines                                                                    |
+| `one-space-between-tags`                            | Tags on the same line must be separated by a single space                                                          |
+| [`required-tags`](#required-tags)                   | Require tags/patterns of tags on Scenarios                                                                         |
+| [`scenario-size`](#scenario-size)                   | Allows restricting the maximum number of steps in a scenario, scenario outline and background                      |
+| `use-and`                                           | Disallows repeated step names requiring use of And instead                                                         |
+| `keywords-in-logical-order`                         | Requires that Given, When and Then appear in logical sequence                                                      |
 
 \* These rules cannot be turned off because they detect undocumented cucumber functionality that causes the [gherkin](https://github.com/cucumber/gherkin-javascript) parser to crash.
 
 ## Rule Configuration
+
 The not-configurable rules are turned on by default and cannot be turned off. Configurable rules can be customized using a [file](#configuration-file).
 
 The configurable rules are off by default. To turn them on, you will need to create a json file, where you specify the name of each rule and its desired state (which can be "on" or "off"). Eg:
+
 ```
 {
   "no-unnamed-features": "on"
 }
 ```
+
 will turn on the `no-unnamed-features` rule.
 
 ### allowed-tags
@@ -93,7 +99,7 @@ Any tag not included in this list won't be allowed.
 
 ```json
 {
-  "file-name": ["on", {"style": "PascalCase"}]
+  "file-name": ["on", { "style": "PascalCase" }]
 }
 ```
 
@@ -110,6 +116,7 @@ The list of supported styles is:
 `no-restricted-patterns` is a list of exact or partial patterns whose matches are dissallowed in feature name and description, and in background, scenario and scenario outline name, description and steps.
 All patterns are treated as case insensitive.
 The rule can be configured like this:
+
 ```
 {
   "no-restricted-patterns": ["on", {
@@ -134,16 +141,19 @@ The rule can be configured like this:
 ```
 
 Notes:
+
 - Step keywords `Given`, `When`, `Then` and `And` should not be included in the patterns.
 - Description violations always get reported in the Feature/Scenario/etc definition line. This is due to the parsed gherkin tree not having information about which line the description appears.
 
 ### indentation
 
 `indentation` can be configured in a more granular level and uses following rules by default:
+
 - Expected indentation for Feature, Background, Scenario, Examples heading: 0 spaces
 - Expected indentation for Steps and each example: 2 spaces
 
 You can override the defaults for `indentation` like this:
+
 ```
 {
   "indentation" : [
@@ -165,24 +175,25 @@ You can override the defaults for `indentation` like this:
   ]
 }
 ```
-There is no need to override all the defaults, as is done above, instead they can be overriden only where required.  `Step` will be used as a fallback if the keyword of the step, eg. 'given', is not specified.  If `feature tag` is not set then `Feature` is used as a fallback, and if `scenario tag` is not set then `Scenario` is used as a fallback.
+
+There is no need to override all the defaults, as is done above, instead they can be overriden only where required. `Step` will be used as a fallback if the keyword of the step, eg. 'given', is not specified. If `feature tag` is not set then `Feature` is used as a fallback, and if `scenario tag` is not set then `Scenario` is used as a fallback.
 
 This feature is able to handle all localizations of the gherkin steps.
 
-
 ### max-scenarios-per-file
+
 The `max-scenarios-per-file` supports some configuration options:
 
 - `maxScenarios` (number) the maximum scenarios per file after which the rule fails - defaults to `10`
 - `countOutlineExamples` (boolean) whether to count every example row for a Scenario Outline, as opposed to just 1 for the whole block - defaults to `true`
 
 The configuration looks like this (showing the defaults):
+
 ```
 {
   "max-scenarios-per-file": ["on", {"maxScenarios": 10, "countOutlineExamples": true}]
 }
 ```
-
 
 ### name-length
 
@@ -195,23 +206,25 @@ The default is 70 characters for each of these:
 }
 ```
 
-
 ### new-line-at-eof
 
 `new-line-at-eof` can be configured to enforce or disallow new lines at EOF.
+
 - To enforce new lines at EOF:
+
 ```
 {
   "new-line-at-eof": ["on", "yes"]
 }
 ```
+
 - To disallow new lines at EOF:
+
 ```
 {
   "new-line-at-eof": ["on", "no"]
 }
 ```
-
 
 ### no-dupe-scenario-names
 
@@ -240,15 +253,15 @@ or
 }
 ```
 
-
 ### no-restricted-tags
+
 `no-restricted-tags` should be configured with the list of restricted tags and patterns:
+
 ```
 {
   "no-restricted-tags": ["on", {"tags": ["@watch", "@wip"], "patterns": ["^@todo$"]}]
 }
 ```
-
 
 ### required-tags
 
@@ -256,17 +269,18 @@ or
 
 - `tags` (array) the array of tag patterns that must match at least one tag - defaults to `[]`
 - `ignoreUntagged` (boolean) whether to ignore scenarios that have no tag - defaults to `true`
+- `scenarioOutlineExampleTags` (boolean) whether to consider tags on Scenario Outline Examples - defaults to `false`
 
 ```
 {
-  "required-tags": ["on", {"tags": ["^@issue:[1-9]\\d*$"], "ignoreUntagged": false}]
+  "required-tags": ["on", {"tags": ["^@issue:[1-9]\\d*$"], "ignoreUntagged": false, "scenarioOutlineExampleTags:false"}]
 }
 ```
-
 
 ### scenario-size
 
 `scenario-size` lets you specify a maximum step length for scenarios and backgrounds. The `Scenario` configuration applies to both scenarios and scenario outlines:
+
 ```
 {
   "scenario-size": ["on", { "steps-length": { "Background": 15, "Scenario": 15 }}]
@@ -274,6 +288,7 @@ or
 ```
 
 ## Configuration File
+
 The default name for the configuration file is `.gherkin-lintrc` and it's expected to be in your working directory.
 
 The file contents must be valid JSON, though it does allow comments.
@@ -283,15 +298,18 @@ If you are using a file with a different name or a file in a different folder, y
 You can find an example configuration file, that turns on all of the rules in the root of this repo (.gherkin-lintrc).
 
 ## Ignoring Feature Files
-There are 2 ways you can specify files that the linter should ignore:
-1. Add a `.gherkin-lintignore` file in your working directory and specify one glob pattern per file line
-1. Use the command line option`-i` or `--ignore`,  pass in a comma separated list of glob patterns. If specified, the command line option will override the `.gherkin-lintignore` file.
 
+There are 2 ways you can specify files that the linter should ignore:
+
+1. Add a `.gherkin-lintignore` file in your working directory and specify one glob pattern per file line
+1. Use the command line option`-i` or `--ignore`, pass in a comma separated list of glob patterns. If specified, the command line option will override the `.gherkin-lintignore` file.
 
 ## Custom rules
+
 You can specify one more more custom rules directories by using the `-r` or `--rulesdir` command line option. Rules in the given directories will be available additionally to the default rules.
 
 Example:
+
 ```
 gherkin-lint --rulesdir "/path/to/my/rulesdir" --rulesdir "from/cwd/rulesdir"
 ```

--- a/src/rules/required-tags.js
+++ b/src/rules/required-tags.js
@@ -4,18 +4,25 @@ const gherkinUtils = require('./utils/gherkin.js');
 const rule = 'required-tags';
 const availableConfigs = {
   tags: [],
-  ignoreUntagged: true
+  ignoreUntagged: true,
+  scenarioOutlineExampleTags: false,
 };
 
-
-function checkTagExists(requiredTag, ignoreUntagged, scenarioTags, scenarioType, scenarioLine) {
-  const result = (ignoreUntagged && scenarioTags.length == 0)
-    || scenarioTags.some((tagObj) => RegExp(requiredTag).test(tagObj.name));
+function checkTagExists(
+  requiredTag,
+  ignoreUntagged,
+  scenarioTags,
+  scenarioType,
+  scenarioLine
+) {
+  const result =
+    (ignoreUntagged && scenarioTags.length == 0) ||
+    scenarioTags.some((tagObj) => RegExp(requiredTag).test(tagObj.name));
   if (!result) {
     return {
       message: `No tag found matching ${requiredTag} for ${scenarioType}`,
       rule,
-      line: scenarioLine
+      line: scenarioLine,
     };
   }
   return result;
@@ -31,26 +38,48 @@ function run(feature, unused, config) {
   let errors = [];
   feature.children.forEach((child) => {
     if (child.scenario) {
+      let actualTags = [];
+      if (
+        child.scenario.keyword.includes('Scenario Outline') &&
+        mergedConfig.scenarioOutlineExampleTags
+      ) {
+        //tags on the scenario outline
+        actualTags.push(...child.scenario.tags);
+        //tags on the examples a scenario outline can have multiple example blocks
+        child.scenario.examples.forEach((example) => {
+          actualTags.push(...example.tags);
+        });
+        // console.log(child.scenario.name,child.scenario.tags,actualTags)
+      } else {
+        actualTags = child.scenario.tags;
+      }
+
       const type = gherkinUtils.getNodeType(child.scenario, feature.language);
       const line = child.scenario.location.line;
 
       // Check each Scenario for the required tags
       const requiredTagErrors = mergedConfig.tags
-        .map((requiredTag) => checkTagExists(requiredTag, mergedConfig.ignoreUntagged, child.scenario.tags || [], type, line))
-        .filter((item) =>
-          typeof item === 'object' && item.message
-        );
+        .map((requiredTag) =>
+          checkTagExists(
+            requiredTag,
+            mergedConfig.ignoreUntagged,
+            actualTags,
+            type,
+            line
+          )
+        )
+        .filter((item) => typeof item === 'object' && item.message);
 
       // Update errors
       errors = errors.concat(requiredTagErrors);
     }
   });
-  
+
   return errors;
 }
 
 module.exports = {
   name: rule,
   run: run,
-  availableConfigs: availableConfigs
+  availableConfigs: availableConfigs,
 };


### PR DESCRIPTION
PR to add an option to Required Tags that will consider tags on Scenario Outline Examples.  

option: `scenarioOutlineExampleTags`

When `true` linting will not fail for usage like this:

```gherkin
Scenario Outline: Some repeatable scenario
  Given I some precondition
  When I do something
  Then I expect Something
  
 @tag1
 Examples:
 
 @tag2
 Examples:
```