### PR TITLE
Make accessible as pre-commit hook

### DIFF
--- a/.pre-commit-hooks.yaml
+++ b/.pre-commit-hooks.yaml
@@ -1,0 +1,6 @@
+- id: gherkin-lint
+  name: gherkin-lint
+  description: Check whether your feature-files are consistingly following a given set of rules.
+  entry: gherkin-lint
+  language: node
+  files: ".*feature"


### PR DESCRIPTION
To ease the automated local usage and the usage within CI-pipelines using pre-commit (https://pre-commit.com/), a .pre-commit-hooks.yaml has been added, providing a basic configuration that should be usable for a wide range of projects.