### PR TITLE
Add --max-errors command line option

### DIFF
--- a/README.md
+++ b/README.md
@@ -298,3 +298,8 @@ gherkin-lint --rulesdir "/path/to/my/rulesdir" --rulesdir "from/cwd/rulesdir"
 
 Paths can either be absolute or relative to the current working directory.
 Have a look at the `src/rules/` directory for examples; The `no-empty-file` rule is a good example to start with.
+
+## Max errors
+You can set a maximum number of errors using the `--max-errors` command line option. This defaults to 0 if not passed.
+
+When the total number of errors is less or equal to the `max-errors` amount, the process will exit successfully (0 exit status).

--- a/src/count-errors.js
+++ b/src/count-errors.js
@@ -1,0 +1,9 @@
+function countErrors(results) {
+  let total = 0;
+  for (let result of results) {
+    total += result.errors.length;
+  }
+  return total;
+}
+
+module.exports = { countErrors };

--- a/src/formatters/stylish.js
+++ b/src/formatters/stylish.js
@@ -1,5 +1,6 @@
 /*eslint no-console: "off"*/
 import 'core-js/stable/string';
+import { countErrors } from '../count-errors';
 
 const style = {
   gray: function(text) {
@@ -74,6 +75,8 @@ function printResults(results) {
       console.error('\n');
     }
   });
+
+  console.log(countErrors(results) + ' errors');
 }
 
 module.exports = {

--- a/src/main.js
+++ b/src/main.js
@@ -4,7 +4,7 @@ const program = require('commander');
 const linter = require('./linter.js');
 const featureFinder = require('./feature-finder.js');
 const configParser = require('./config-parser.js');
-const logger = require('./logger.js');
+const { handleResults } = require('./results-handler.js');
 
 function list(val) {
   return val.split(',');
@@ -21,6 +21,7 @@ program
   .option('-i, --ignore <...>', 'comma seperated list of files/glob patterns that the linter should ignore, overrides ' + featureFinder.defaultIgnoreFileName + ' file', list)
   .option('-c, --config [config]', 'configuration file, defaults to ' + configParser.defaultConfigFileName)
   .option('-r, --rulesdir <...>', 'additional rule directories', collect, [])
+  .option('-r, --max-errors [number]', 'maximum number of errors to pass. Defaults to 0', 0)
   .parse(process.argv);
 
 const additionalRulesDirs = program.rulesdir;
@@ -28,31 +29,5 @@ const files = featureFinder.getFeatureFiles(program.args, program.ignore);
 const config = configParser.getConfiguration(program.config, additionalRulesDirs);
 linter.lint(files, config, additionalRulesDirs)
   .then((results) => {
-    printResults(results, program.format);
-    process.exit(getExitCode(results));
+    handleResults(results, program);
   });
-
-function getExitCode(results) {
-  let exitCode = 0;
-  results.forEach(result => {
-    if (result.errors.length > 0) {
-      exitCode = 1;
-    }
-  });
-  return exitCode;
-}
-
-function printResults(results, format) {
-  let formatter;
-  if (format === 'json') {
-    formatter = require('./formatters/json.js');
-  } else if (format === 'xunit') {
-    formatter = require('./formatters/xunit.js');
-  } else if (!format || format === 'stylish') {
-    formatter = require('./formatters/stylish.js');
-  } else {
-    logger.boldError('Unsupported format. The supported formats are json, xunit and stylish.');
-    process.exit(1);
-  }
-  formatter.printResults(results);
-}

--- a/src/results-handler.js
+++ b/src/results-handler.js
@@ -1,0 +1,35 @@
+const logger = require('./logger.js');
+const { countErrors } = require('./count-errors.js');
+
+function handleResults(results, options) {
+  printResults(results, options.format);
+  process.exit(getExitCode(results, options.maxErrors));
+}
+
+function getExitCode(results, maxErrors) {
+  let exitCode = 0;
+  const numberOfErrors = countErrors(results);
+
+  if (numberOfErrors > maxErrors) {
+    exitCode = 1;
+  }
+  return exitCode;
+}
+
+function printResults(results, format) {
+  let formatter;
+  if (format === 'json') {
+    formatter = require('./formatters/json.js');
+  } else if (format === 'xunit') {
+    formatter = require('./formatters/xunit.js');
+  } else if (!format || format === 'stylish') {
+    formatter = require('./formatters/stylish.js');
+  } else {
+    logger.boldError('Unsupported format. The supported formats are json, xunit and stylish.');
+    process.exit(1);
+  }
+  formatter.printResults(results);
+}
+
+
+module.exports = { handleResults };

--- a/test/results-handler/results-handler.js
+++ b/test/results-handler/results-handler.js
@@ -1,0 +1,93 @@
+var expect = require('chai').expect;
+var { handleResults } = require('../../dist/results-handler');
+
+
+describe('Results handler', function() {
+
+  describe('configuration', function() {
+    beforeEach(function() {
+      this.sinon.stub(console, 'error');
+      this.sinon.stub(process, 'exit');
+    });
+
+    afterEach(function() {
+      console.error.restore(); // eslint-disable-line no-console
+      process.exit.restore();
+    });
+  });
+
+  const results = [
+    {
+      errors: [
+        { // This one is to make sure we don't accidentally regress and always load the default rules
+          line: 1,
+          message: 'Wrong indentation for "Feature", expected indentation level of 0, but got 4',
+          rule: 'indentation'
+        },
+        {
+          line: 109,
+          message: 'Another custom-list error',
+          rule: 'another-custom-list'
+        },
+      ],
+      filePath: 'first-feature-file-name'
+    }, {
+      errors: [
+        {
+          line: 32,
+          message: 'Custom error',
+          rule: 'custom'
+        }
+      ],
+      filePath: 'second-feature-file-name'
+    }
+  ];
+
+  it('raises an error when number of errors is more than maxErrors', function() {
+    handleResults(results, { format: 'json', maxErrors: 2 });
+
+    const numberOfErrorsMessage = '3 errors';
+
+    var consoleLogArgs = console.log.args.map(function (args) { // eslint-disable-line no-console
+      return args[0];
+    });
+    expect(consoleLogArgs[0]).to.include(numberOfErrorsMessage);
+    expect(process.exit.args[0][0]).to.equal(1);
+  });
+
+  it('doesn\'t raise errors when the error count is equal to maxErrors', function() {
+    handleResults(results, { format: 'json', maxErrors: 3 });
+
+    var numberOfErrorsMessage = '3 errors';
+
+    var consoleLogArgs = console.log.args.map(function (args) { // eslint-disable-line no-console
+      return args[0];
+    });
+    expect(consoleLogArgs[0]).to.include(numberOfErrorsMessage);
+    expect(process.exit.args[0][0]).to.equal(0);
+  });
+
+  it('doesn\'t raise errors when the error count is less than maxErrors', function() {
+    handleResults(results, { format: 'json', maxErrors: 4 });
+
+    var numberOfErrorsMessage = '3 errors';
+
+    var consoleLogArgs = console.log.args.map(function (args) { // eslint-disable-line no-console
+      return args[0];
+    });
+    expect(consoleLogArgs[0]).to.include(numberOfErrorsMessage);
+    expect(process.exit.args[0][0]).to.equal(0);
+  });
+
+  it('doesn\'t raise errors when the error count is 0', function() {
+    handleResults([], { format: 'json', maxErrors: 4 });
+
+    var numberOfErrorsMessage = '0 errors';
+
+    var consoleLogArgs = console.log.args.map(function (args) { // eslint-disable-line no-console
+      return args[0];
+    });
+    expect(consoleLogArgs[0]).to.include(numberOfErrorsMessage);
+    expect(process.exit.args[0][0]).to.equal(0);
+  });
+});


### PR DESCRIPTION
Adds the ability for users to set a maximum number of errors before the process fails (non-zero exit code).

This is similar to ESLint's max-warnings option. https://www.eslint.com.cn/docs/2.0.0/user-guide/command-line-interface#--max-warnings

My team has recently adopted gherkin-lint and has a lot of errors. Rather than disabling rules or allowing our CI builds to pass on any amount of gherkin-lint errors, --max-errors enables us to iteratively fix errors and lower our maximum over time.