### PR TITLE
Allow requiring CJS files

### DIFF
--- a/src/rules.js
+++ b/src/rules.js
@@ -4,14 +4,14 @@ const path = require('path');
 
 function getAllRules(additionalRulesDirs) {
   let rules = {};
-  
+
   const rulesDirs = [
     path.join(__dirname, 'rules')
   ].concat(additionalRulesDirs || []);
 
   rulesDirs.forEach(rulesDir => {
     rulesDir = path.resolve(rulesDir);
-    glob.sync(`${rulesDir}/*.js`).forEach(file => {
+    glob.sync(`${rulesDir}/*.{js,cjs}`).forEach(file => {
       const rule = require(file);
       rules[rule.name] = rule;
     });

--- a/test/rulesdir/.gherkin-lintrc
+++ b/test/rulesdir/.gherkin-lintrc
@@ -2,5 +2,6 @@
   "indentation": "on",
   "custom" : "on",
   "another-custom" : "on",
-  "another-custom-list" : ["on", {"element": ["first_element"]}]
+  "another-custom-list" : ["on", {"element": ["first_element"]}],
+  "commonjs-custom": "on"
 }

--- a/test/rulesdir/other_rules/commonjs.cjs
+++ b/test/rulesdir/other_rules/commonjs.cjs
@@ -1,0 +1,17 @@
+var rule = 'commonjs-custom';
+
+function custom() {
+  return [
+    {
+      message: 'CommonJS custom error',
+      rule   : rule,
+      line   : 789
+    }
+  ];
+}
+
+module.exports = {
+  name: rule,
+  run: custom,
+  availableConfigs: []
+};

--- a/test/rulesdir/rulesdir.js
+++ b/test/rulesdir/rulesdir.js
@@ -35,11 +35,16 @@ describe('rulesdir CLI option', function() {
                 line: 456,
                 message: 'Another custom error',
                 rule: 'another-custom'
+              },
+              {
+                line: 789,
+                message: 'CommonJS custom error',
+                rule: 'commonjs-custom'
               }
             ],
             filePath: featureFile
           }
         ]);
       });
-  });    
+  });
 });


### PR DESCRIPTION
This MR adds the ability to require CJS files.

In ESM projects, any use of CommonJS needs to be in a CJS file.